### PR TITLE
Relax tool execution exception signature for lint compatibility

### DIFF
--- a/MCP/PDF/src/pdf_mcp_server/__init__.py
+++ b/MCP/PDF/src/pdf_mcp_server/__init__.py
@@ -20,6 +20,7 @@ from .models import (
     TextExtractionResult,
     TableExtractionResult,
     FormulaExtractionResult,
+    LayoutReconstructionResult,
     PDFInfo,
 )
 
@@ -29,5 +30,6 @@ __all__ = [
     "TextExtractionResult",
     "TableExtractionResult",
     "FormulaExtractionResult",
+    "LayoutReconstructionResult",
     "PDFInfo",
 ]

--- a/MCP/PDF/src/pdf_mcp_server/cli.py
+++ b/MCP/PDF/src/pdf_mcp_server/cli.py
@@ -34,7 +34,13 @@ src_path = Path(__file__).parent.parent
 if str(src_path) not in sys.path:
     sys.path.insert(0, str(src_path))
 
-from pdf_mcp_server.core import PDFProcessor, ProcessingRequest
+from pdf_mcp_server.models import (
+    FormulaModel,
+    ProcessingMode,
+    ProcessingRequest,
+    TableEngine,
+)
+from pdf_mcp_server.processors.pdf_processor import PDFProcessor
 from pdf_mcp_server.utils import Config, setup_logging, get_logger
 from pdf_mcp_server.main import main as server_main
 
@@ -60,7 +66,7 @@ def cli(ctx, config: Optional[str], verbose: bool, quiet: bool):
     else:
         log_level = 'INFO'
     
-    setup_logging(level=log_level)
+    setup_logging(log_level=log_level)
     
     # Load configuration
     try:
@@ -90,7 +96,8 @@ def cli(ctx, config: Optional[str], verbose: bool, quiet: bool):
 @click.option('--include-ocr/--no-ocr', default=True, help='Include OCR processing')
 @click.option('--include-formulas/--no-formulas', default=False, help='Include formula extraction')
 @click.option('--include-grobid/--no-grobid', default=False, help='Include GROBID processing')
-@click.option('--table-engine', 
+@click.option('--reconstruct-layout/--no-reconstruct-layout', default=False, help='Rebuild layout using extracted content')
+@click.option('--table-engine',
               type=click.Choice(['camelot', 'tabula', 'pdfplumber', 'auto']),
               default='auto', help='Table extraction engine')
 @click.option('--formula-model',
@@ -98,8 +105,8 @@ def cli(ctx, config: Optional[str], verbose: bool, quiet: bool):
               default='auto', help='Formula recognition model')
 @click.pass_context
 def process(ctx, file: str, mode: str, pages: Optional[str], output: Optional[str],
-           output_format: str, include_ocr: bool, include_formulas: bool, 
-           include_grobid: bool, table_engine: str, formula_model: str):
+           output_format: str, include_ocr: bool, include_formulas: bool,
+           include_grobid: bool, reconstruct_layout: bool, table_engine: str, formula_model: str):
     """Process a PDF file with specified options."""
     config = ctx.obj.get('config')
     verbose = ctx.obj.get('verbose', False)
@@ -146,21 +153,21 @@ def process(ctx, file: str, mode: str, pages: Optional[str], output: Optional[st
                         else:
                             parsed_pages = [int(pages)]
                     
-                    # Create processing request
-                    options = {
-                        'include_ocr': include_ocr,
-                        'include_formulas': include_formulas,
-                        'include_grobid': include_grobid,
-                        'table_engine': table_engine,
-                        'formula_model': formula_model
-                    }
-                    
+                    table_engine_enum = TableEngine.CAMELOT if table_engine == 'auto' else TableEngine(table_engine)
+                    formula_model_enum = FormulaModel.PIX2TEX if formula_model == 'auto' else FormulaModel(formula_model)
+                    mode_enum = ProcessingMode.FULL if mode == 'process_ocr' else ProcessingMode(mode)
+
                     request = ProcessingRequest(
                         file_path=str(file_path),
-                        mode=mode,
+                        mode=mode_enum,
                         pages=parsed_pages,
                         output_format=output_format,
-                        options=options
+                        include_ocr=include_ocr,
+                        include_formulas=include_formulas,
+                        include_grobid=include_grobid,
+                        reconstruct_layout=reconstruct_layout,
+                        table_engine=table_engine_enum,
+                        formula_model=formula_model_enum,
                     )
                     
                     # Process file
@@ -183,21 +190,21 @@ def process(ctx, file: str, mode: str, pages: Optional[str], output: Optional[st
                     else:
                         parsed_pages = [int(pages)]
                 
-                # Create processing request
-                options = {
-                    'include_ocr': include_ocr,
-                    'include_formulas': include_formulas,
-                    'include_grobid': include_grobid,
-                    'table_engine': table_engine,
-                    'formula_model': formula_model
-                }
-                
+                table_engine_enum = TableEngine.CAMELOT if table_engine == 'auto' else TableEngine(table_engine)
+                formula_model_enum = FormulaModel.PIX2TEX if formula_model == 'auto' else FormulaModel(formula_model)
+                mode_enum = ProcessingMode.FULL if mode == 'process_ocr' else ProcessingMode(mode)
+
                 request = ProcessingRequest(
                     file_path=str(file_path),
-                    mode=mode,
+                    mode=mode_enum,
                     pages=parsed_pages,
                     output_format=output_format,
-                    options=options
+                    include_ocr=include_ocr,
+                    include_formulas=include_formulas,
+                    include_grobid=include_grobid,
+                    reconstruct_layout=reconstruct_layout,
+                    table_engine=table_engine_enum,
+                    formula_model=formula_model_enum,
                 )
                 
                 result = await processor.process(request)
@@ -209,7 +216,7 @@ def process(ctx, file: str, mode: str, pages: Optional[str], output: Optional[st
                 
                 if output_format == 'json':
                     with open(output_path, 'w', encoding='utf-8') as f:
-                        json.dump(result.dict(), f, indent=2, ensure_ascii=False)
+                        json.dump(result.model_dump(), f, indent=2, ensure_ascii=False)
                 else:
                     # Handle other formats based on result content
                     with open(output_path, 'w', encoding='utf-8') as f:
@@ -220,10 +227,11 @@ def process(ctx, file: str, mode: str, pages: Optional[str], output: Optional[st
             else:
                 # Print to console
                 if output_format == 'json':
+                    dumped = result.model_dump()
                     if not quiet:
-                        console.print(Panel(JSON(json.dumps(result.dict(), indent=2)), title="Processing Results"))
+                        console.print(Panel(JSON(json.dumps(dumped, indent=2)), title="Processing Results"))
                     else:
-                        print(json.dumps(result.dict(), indent=2))
+                        print(json.dumps(dumped, indent=2))
                 else:
                     if not quiet:
                         console.print(Panel(str(result), title="Processing Results"))
@@ -403,9 +411,10 @@ def health(ctx, url: str, timeout: int):
               default='json', help='Output format')
 @click.option('--parallel/--sequential', default=True, help='Process files in parallel')
 @click.option('--max-workers', type=int, default=4, help='Maximum number of parallel workers')
+@click.option('--reconstruct-layout/--no-reconstruct-layout', default=False, help='Rebuild layout using extracted content')
 @click.pass_context
 def batch(ctx, files: List[str], mode: str, output_dir: Optional[str],
-         output_format: str, parallel: bool, max_workers: int):
+         output_format: str, parallel: bool, max_workers: int, reconstruct_layout: bool):
     """Process multiple PDF files in batch."""
     config = ctx.obj.get('config')
     quiet = ctx.obj.get('quiet', False)
@@ -456,11 +465,12 @@ def batch(ctx, files: List[str], mode: str, output_dir: Optional[str],
                         try:
                             request = ProcessingRequest(
                                 file_path=file_path,
-                                mode=mode,
-                                output_format=output_format
+                                mode=ProcessingMode.FULL if mode == 'process_ocr' else ProcessingMode(mode),
+                                output_format=output_format,
+                                reconstruct_layout=reconstruct_layout
                             )
                             result = await processor.process(request)
-                            return {'file': file_path, 'result': result, 'success': True}
+                            return {'file': file_path, 'result': result.model_dump(), 'success': True}
                         except Exception as e:
                             return {'file': file_path, 'error': str(e), 'success': False}
                 
@@ -475,11 +485,12 @@ def batch(ctx, files: List[str], mode: str, output_dir: Optional[str],
                         
                         request = ProcessingRequest(
                             file_path=file_path,
-                            mode=mode,
-                            output_format=output_format
+                            mode=ProcessingMode.FULL if mode == 'process_ocr' else ProcessingMode(mode),
+                            output_format=output_format,
+                            reconstruct_layout=reconstruct_layout
                         )
                         result = await processor.process(request)
-                        results.append({'file': file_path, 'result': result, 'success': True})
+                        results.append({'file': file_path, 'result': result.model_dump(), 'success': True})
                     except Exception as e:
                         results.append({'file': file_path, 'error': str(e), 'success': False})
             
@@ -494,7 +505,7 @@ def batch(ctx, files: List[str], mode: str, output_dir: Optional[str],
                         output_file = output_path / f"{file_name}_result.{output_format}"
                         with open(output_file, 'w', encoding='utf-8') as f:
                             if output_format == 'json':
-                                json.dump(result['result'].dict(), f, indent=2, ensure_ascii=False)
+                                json.dump(result['result'], f, indent=2, ensure_ascii=False)
                             else:
                                 f.write(str(result['result']))
                     else:

--- a/MCP/PDF/src/pdf_mcp_server/http_app.py
+++ b/MCP/PDF/src/pdf_mcp_server/http_app.py
@@ -107,6 +107,10 @@ async def extract(
     table_engine: TableEngine = Query(default=TableEngine.CAMELOT),
     formula_model: FormulaModel = Query(default=FormulaModel.LATEX_OCR),
     output_format: str = Query(default="json"),
+    reconstruct_layout: bool = Query(
+        default=False,
+        description="Reconstruct layout and return structured layout output",
+    ),
     async_mode: bool = Query(default=False, description="Queue job asynchronously and return task id"),
 ):
     if not _processor or not _config:
@@ -120,7 +124,9 @@ async def extract(
             # Save upload to a temporary file
             suffix = Path(file.filename or "uploaded.pdf").suffix or ".pdf"
             fd, tmp = tempfile.mkstemp(suffix=suffix)
-            Path(tmp).write_bytes(await file.read())
+            data = await file.read()
+            with os.fdopen(fd, 'wb') as tmp_file:
+                tmp_file.write(data)
             local_path = Path(tmp)
             tmp_path = local_path
         elif file_path:
@@ -141,6 +147,7 @@ async def extract(
             include_grobid=include_grobid,
             table_engine=table_engine,
             formula_model=formula_model,
+            reconstruct_layout=reconstruct_layout,
         )
 
         if async_mode:
@@ -159,6 +166,7 @@ async def extract(
                         "table_engine": table_engine.value if hasattr(table_engine, "value") else str(table_engine),
                         "formula_model": formula_model.value if hasattr(formula_model, "value") else str(formula_model),
                         "output_format": output_format,
+                        "reconstruct_layout": reconstruct_layout,
                     },
                 )
                 return JSONResponse(jsonable_encoder({"task_id": job.get_id(), "status": "queued"}))
@@ -170,13 +178,13 @@ async def extract(
                     try:
                         _tasks[task_id] = {"status": "running"}
                         result = await _processor.process(req)
-                        task_payload: Dict[str, Any] = {"status": "finished", "result": result.dict()}
+                        task_payload: Dict[str, Any] = {"status": "finished", "result": result.model_dump()}
                         if output_format == "docx":
                             out_dir = Path(os.getenv("PDF_MCP_DOCX_DIR", tempfile.gettempdir())) / "pdf_mcp_docx"
                             out_dir.mkdir(parents=True, exist_ok=True)
                             out_path = out_dir / f"export_{local_path.stem}.docx"
                             from .utils.docx_exporter import build_docx_from_pipeline
-                            build_docx_from_pipeline(result.dict(), out_path)
+                            build_docx_from_pipeline(result.model_dump(), out_path)
                             task_payload["docx_path"] = str(out_path)
                         _tasks[task_id] = task_payload
                     except Exception as e:  # pylint: disable=broad-except
@@ -198,7 +206,7 @@ async def extract(
             out_dir = Path(os.getenv("PDF_MCP_DOCX_DIR", tempfile.gettempdir())) / "pdf_mcp_docx"
             out_dir.mkdir(parents=True, exist_ok=True)
             out_path = out_dir / f"export_{local_path.stem}.docx"
-            build_docx_from_pipeline(result.dict(), out_path)
+            build_docx_from_pipeline(result.model_dump(), out_path)
             return FileResponse(
                 path=str(out_path),
                 media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",

--- a/MCP/PDF/src/pdf_mcp_server/main.py
+++ b/MCP/PDF/src/pdf_mcp_server/main.py
@@ -37,7 +37,7 @@ from .models import (
 )
 from .processors import PDFProcessor  # PDF处理器
 from .utils.config import Config  # 配置管理
-from .utils.logger import setup_logging  # 日志设置
+from .utils.logging_config import setup_logging  # 日志设置
 from .utils.exceptions import PDFProcessingError, ValidationError  # 自定义异常
 
 # 全局变量定义
@@ -136,7 +136,7 @@ async def pdf_processing_exception_handler(request, exc: PDFProcessingError):
             error_code="PDF_PROCESSING_ERROR",  # 错误代码
             message=str(exc),  # 错误消息
             details={"type": type(exc).__name__}  # 错误详情
-        ).dict()
+        ).model_dump()
     )
 
 
@@ -153,7 +153,7 @@ async def validation_exception_handler(request, exc: ValidationError):
             error_code="VALIDATION_ERROR",  # 验证错误代码
             message=str(exc),  # 错误消息
             details=exc.details if hasattr(exc, 'details') else {}  # 错误详情
-        ).dict()
+        ).model_dump()
     )
 
 
@@ -201,6 +201,7 @@ async def upload_and_process(
     include_ocr: bool = Form(True),  # 是否包含OCR处理，默认为True
     include_formulas: bool = Form(False),  # 是否包含公式识别，默认为False
     include_grobid: bool = Form(False),  # 是否包含GROBID处理，默认为False
+    reconstruct_layout: bool = Form(False),  # 是否执行版面重建
     processor: PDFProcessor = Depends(get_pdf_processor)  # 依赖注入PDF处理器
 ):
     """Upload and process PDF file.
@@ -231,7 +232,8 @@ async def upload_and_process(
             mode=mode,  # 处理模式
             include_ocr=include_ocr,  # 是否包含OCR
             include_formulas=include_formulas,  # 是否包含公式识别
-            include_grobid=include_grobid  # 是否包含GROBID处理
+            include_grobid=include_grobid,  # 是否包含GROBID处理
+            reconstruct_layout=reconstruct_layout  # 是否执行版面重建
         )
         
         # 调用处理器执行PDF处理

--- a/MCP/PDF/src/pdf_mcp_server/mcp/exceptions.py
+++ b/MCP/PDF/src/pdf_mcp_server/mcp/exceptions.py
@@ -106,28 +106,54 @@ class InvalidToolCallException(MCPException):
 
 class ToolExecutionException(MCPException):
     """Exception raised when tool execution fails."""
-    
+
     def __init__(
         self,
-        tool_name: str,
-        execution_error: str,
-        original_exception: Optional[Exception] = None
+        tool_name_or_message: str,
+        execution_error: Optional[str] = None,
+        original_exception: Optional[Exception] = None,
+        *,
+        tool_name: Optional[str] = None,
     ):
-        message = f"Tool '{tool_name}' execution failed: {execution_error}"
+        """Create a tool execution error.
+
+        The historical call-site signature was ``ToolExecutionException(message)``
+        even though the class originally required both ``tool_name`` and an error
+        string.  Pylint correctly flagged these calls as missing required
+        arguments.  To remain backward compatible (and to keep the call-sites
+        simple for generic tools) we accept either ``ToolExecutionException("msg")``
+        or ``ToolExecutionException("tool", "msg")`` as well as the explicit
+        keyword form ``ToolExecutionException("msg", tool_name="tool")``.
+        """
+
+        if execution_error is None and tool_name is None:
+            # Called with only a message. Use a generic tool name so the final
+            # message still reads naturally.
+            resolved_tool_name = "generic_tool"
+            resolved_error = tool_name_or_message
+            final_message = f"Tool execution failed: {resolved_error}"
+        else:
+            # Either the legacy two-argument form or explicit keyword usage.
+            resolved_tool_name = tool_name or tool_name_or_message
+            resolved_error = execution_error or tool_name_or_message
+            final_message = (
+                f"Tool '{resolved_tool_name}' execution failed: {resolved_error}"
+            )
+
         details = {
-            'tool_name': tool_name,
-            'execution_error': execution_error
+            'tool_name': resolved_tool_name,
+            'execution_error': resolved_error,
         }
-        
+
         if original_exception:
             details['original_exception'] = {
                 'type': type(original_exception).__name__,
                 'message': str(original_exception)
             }
-        
-        super().__init__(message, 'TOOL_EXECUTION_ERROR', details)
-        self.tool_name = tool_name
-        self.execution_error = execution_error
+
+        super().__init__(final_message, 'TOOL_EXECUTION_ERROR', details)
+        self.tool_name = resolved_tool_name
+        self.execution_error = resolved_error
         self.original_exception = original_exception
 
 

--- a/MCP/PDF/src/pdf_mcp_server/mcp/server.py
+++ b/MCP/PDF/src/pdf_mcp_server/mcp/server.py
@@ -170,7 +170,7 @@ class MCPServer:
     
     def list_tools(self) -> List[Dict[str, Any]]:
         """List all registered tools."""
-        return [tool_info["definition"].dict() for tool_info in self.tools.values()]
+        return [tool_info["definition"].model_dump() for tool_info in self.tools.values()]
     
     def list_tool_names(self) -> List[str]:
         """List all registered tool names."""
@@ -357,7 +357,7 @@ class MCPServer:
         
         self.logger.info(f"Initialized with client: {self.client_info.name} v{self.client_info.version}")
         
-        return result.dict(exclude_none=True)
+        return result.model_dump(exclude_none=True)
     
     async def _handle_ping(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Handle ping request."""
@@ -365,7 +365,7 @@ class MCPServer:
     
     async def _handle_list_tools(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Handle list tools request."""
-        tools = [tool_info["definition"].dict() for tool_info in self.tools.values()]
+        tools = [tool_info["definition"].model_dump() for tool_info in self.tools.values()]
         return {"tools": tools}
     
     async def _handle_call_tool(self, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -387,13 +387,13 @@ class MCPServer:
             
             # Ensure result is in correct format
             if isinstance(result, MCPToolResult):
-                return result.dict()
+                return result.model_dump()
             elif isinstance(result, dict) and "content" in result:
                 return result
             else:
                 # Wrap simple results
                 content = [create_text_content(str(result))]
-                return MCPToolResult(content=content).dict()
+                return MCPToolResult(content=content).model_dump()
         
         except Exception as e:
             self.logger.error(f"Tool execution error: {e}")
@@ -401,7 +401,7 @@ class MCPServer:
             
             # Return error result
             content = [create_error_content(str(e))]
-            return MCPToolResult(content=content, isError=True).dict()
+            return MCPToolResult(content=content, isError=True).model_dump()
     
     async def _handle_list_resources(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Handle list resources request."""

--- a/MCP/PDF/src/pdf_mcp_server/models.py
+++ b/MCP/PDF/src/pdf_mcp_server/models.py
@@ -22,10 +22,15 @@ from datetime import datetime  # 日期时间处理
 # 第三方库导入
 from pydantic import BaseModel, Field, field_validator  # 数据验证和序列化框架
 
+try:
+    from . import __version__ as _PACKAGE_VERSION
+except ImportError:  # pragma: no cover - package metadata fallback
+    _PACKAGE_VERSION = "0.0.0"
+
 
 class ProcessingMode(str, Enum):
     """可用的PDF处理模式枚举
-    
+
     定义了PDF处理器支持的不同处理模式，每种模式对应不同的功能组合。
     """
     TEXT = "read_text"  # 纯文本提取模式
@@ -132,21 +137,51 @@ class PDFInfo(BaseModel):
     keywords: Optional[str] = Field(None, description="PDF关键词")
 
 
+class TextSpan(BaseModel):
+    """文本片段的样式信息"""
+
+    text: str = Field(..., description="片段文本内容")
+    font: Optional[str] = Field(None, description="字体名称")
+    size: Optional[float] = Field(None, description="字号（pt）")
+    bold: bool = Field(False, description="是否加粗")
+    italic: bool = Field(False, description="是否斜体")
+
+
+class TextLine(BaseModel):
+    """单行文本及其边界框"""
+
+    text: str = Field(..., description="文本内容")
+    bbox: Optional[BoundingBox] = Field(None, description="文本行的边界框")
+    spans: List[TextSpan] = Field(default_factory=list, description="行内样式片段")
+
+
+class TextBlock(BaseModel):
+    """具有定位信息的文本块"""
+
+    text: str = Field(..., description="文本块内容")
+    bbox: BoundingBox = Field(..., description="文本块边界框")
+    lines: List[TextLine] = Field(default_factory=list, description="文本块中的行列表")
+    spans: List[TextSpan] = Field(default_factory=list, description="文本块的样式片段集合")
+    alignment: Optional[str] = Field(None, description="文本块推断的对齐方式")
+
+
 class PageText(BaseModel):
     """单页文本内容模型
-    
+
     表示PDF单个页面的文本提取结果，包含文本内容和相关元数据。
-    
+
     Attributes:
         page: 页码（从1开始）
         text: 提取的文本内容
         bbox: 文本边界框列表（可选）
+        blocks: 文本块集合（可选）
         confidence: OCR置信度分数（可选）
         language: 检测到的语言（可选）
     """
     page: int = Field(..., description="页码（从1开始）")
     text: str = Field(..., description="提取的文本内容")
     bbox: Optional[List[BoundingBox]] = Field(None, description="文本边界框列表")
+    blocks: List[TextBlock] = Field(default_factory=list, description="包含定位信息的文本块列表")
     confidence: Optional[float] = Field(None, description="OCR置信度分数")
     language: Optional[str] = Field(None, description="检测到的语言")
 
@@ -285,6 +320,47 @@ class GrobidResult(BaseModel):
     tei_xml: Optional[str] = Field(None, description="完整的TEI XML输出")
 
 
+class LayoutElementType(str, Enum):
+    """版面元素类型枚举"""
+
+    TEXT = "text"
+    TABLE = "table"
+    FORMULA = "formula"
+    IMAGE = "image"
+    OTHER = "other"
+
+
+class LayoutElement(BaseModel):
+    """单个版面元素的描述"""
+
+    element_id: str = Field(..., description="元素唯一标识符")
+    type: LayoutElementType = Field(..., description="元素类型")
+    bbox: BoundingBox = Field(..., description="元素边界框")
+    text: Optional[str] = Field(None, description="元素文本内容")
+    html: str = Field(..., description="元素对应的HTML片段")
+    metadata: Dict[str, Any] = Field(default_factory=dict, description="额外的元信息")
+
+
+class ReconstructedPage(BaseModel):
+    """单页版面重建结果"""
+
+    page_number: int = Field(..., description="页码（从1开始）")
+    width: float = Field(..., description="页面宽度")
+    height: float = Field(..., description="页面高度")
+    elements: List[LayoutElement] = Field(default_factory=list, description="页面中的元素列表")
+    html: str = Field(..., description="用于渲染页面的HTML")
+
+
+class LayoutReconstructionResult(BaseModel):
+    """版面重建总体结果"""
+
+    method: str = Field(..., description="使用的版面重建方法")
+    processing_time: float = Field(..., description="版面重建耗时（秒）")
+    css: str = Field(..., description="渲染所需的基础CSS")
+    pages: List[ReconstructedPage] = Field(default_factory=list, description="重建后的页面集合")
+    notes: List[str] = Field(default_factory=list, description="处理过程中的提示或警告")
+
+
 class ProcessingMetadata(BaseModel):
     """处理元数据和统计信息模型
     
@@ -303,7 +379,7 @@ class ProcessingMetadata(BaseModel):
     engines_used: List[str] = Field(..., description="使用的引擎/模型列表")
     file_info: PDFInfo = Field(..., description="PDF文件信息")
     timestamp: datetime = Field(default_factory=datetime.now, description="处理时间戳")
-    version: str = Field("0.1.0", description="服务器版本")
+    version: str = Field(_PACKAGE_VERSION, description="服务器版本")
     errors: List[str] = Field(default_factory=list, description="遇到的非致命错误列表")
     warnings: List[str] = Field(default_factory=list, description="生成的警告列表")
 
@@ -318,11 +394,13 @@ class ProcessingContent(BaseModel):
         tables: 表格提取结果（可选）
         formulas: 公式提取结果（可选）
         grobid: GROBID解析结果（可选）
+        layout: 版面重建结果（可选）
     """
     text: Optional[TextExtractionResult] = Field(None, description="文本提取结果")
     tables: Optional[TableExtractionResult] = Field(None, description="表格提取结果")
     formulas: Optional[FormulaExtractionResult] = Field(None, description="公式提取结果")
     grobid: Optional[GrobidResult] = Field(None, description="GROBID解析结果")
+    layout: Optional["LayoutReconstructionResult"] = Field(None, description="版面重建结果")
 
 
 class ProcessingResponse(BaseModel):
@@ -363,6 +441,7 @@ class ProcessingRequest(BaseModel):
         formula_model: 公式识别模型
         formula_confidence_threshold: 公式的最小置信度阈值
         include_grobid: 是否使用GROBID进行学术文档解析
+        reconstruct_layout: 是否执行版面重建
         max_file_size: 最大文件大小限制
         timeout: 处理超时时间
     """
@@ -390,7 +469,10 @@ class ProcessingRequest(BaseModel):
     
     # GROBID选项
     include_grobid: bool = Field(False, description="是否使用GROBID进行学术文档解析")
-    
+
+    # 版面重建
+    reconstruct_layout: bool = Field(False, description="是否执行版面重建以还原原始排版")
+
     # 通用选项
     max_file_size: int = Field(100 * 1024 * 1024, description="最大文件大小（字节）")
     timeout: int = Field(300, description="处理超时时间（秒）")

--- a/MCP/PDF/src/pdf_mcp_server/processors/__init__.py
+++ b/MCP/PDF/src/pdf_mcp_server/processors/__init__.py
@@ -14,6 +14,10 @@ from .table_extractor import TableExtractor
 from .ocr_processor import OCRProcessor
 from .formula_extractor import FormulaExtractor
 from .document_analyzer import DocumentAnalyzer
+try:
+    from .layout_reconstructor import LayoutReconstructor
+except Exception:  # pragma: no cover - optional dependency
+    LayoutReconstructor = None  # type: ignore
 
 __all__ = [
     "PDFProcessor",
@@ -22,4 +26,8 @@ __all__ = [
     "OCRProcessor",
     "FormulaExtractor",
     "DocumentAnalyzer",
+    "LayoutReconstructor",
 ]
+
+if LayoutReconstructor is None:  # pragma: no cover - optional
+    __all__.remove("LayoutReconstructor")

--- a/MCP/PDF/src/pdf_mcp_server/processors/layout_reconstructor.py
+++ b/MCP/PDF/src/pdf_mcp_server/processors/layout_reconstructor.py
@@ -1,0 +1,998 @@
+"""Layout reconstruction processor.
+
+Rebuilds a near-original representation of a PDF page layout using
+previous extraction outputs (text, tables, formulas) and the source PDF
+geometry.
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import math
+import time
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+try:  # Optional dependency
+    import fitz  # type: ignore
+except Exception:  # pragma: no cover - handled at runtime
+    fitz = None
+
+from ..models import (
+    BoundingBox,
+    LayoutElement,
+    LayoutElementType,
+    LayoutReconstructionResult,
+    ProcessingContent,
+    ProcessingRequest,
+    ReconstructedPage,
+    TableData,
+    TextBlock,
+    TextLine,
+    TextSpan,
+)
+from ..utils.config import Config
+from ..utils.exceptions import PDFProcessingError
+from ..utils.geometry import (
+    bbox_distance,
+    bbox_iou,
+    normalize_bbox,
+)
+
+
+@dataclass
+class LayoutBlock:
+    bbox: BoundingBox
+    text: str
+    fonts: List[Dict[str, Any]]
+    lines: List[BoundingBox]
+    spans: List[TextSpan]
+    alignment: Optional[str]
+    line_texts: List[str]
+
+
+@dataclass
+class RecognizedBlock:
+    block: TextBlock
+    bbox: BoundingBox
+
+
+class LayoutReconstructor:
+    """Reconstruct PDF layout using extracted content and document geometry."""
+
+    def __init__(self, config: Config):
+        self.config = config
+        self.logger = logging.getLogger(__name__)
+        self._initialized = False
+
+    async def initialize(self) -> None:
+        """Prepare the reconstructor for use."""
+        if fitz is None:
+            self.logger.warning("PyMuPDF not available; layout reconstruction limited")
+        self._initialized = True
+
+    async def cleanup(self) -> None:
+        """Cleanup internal state."""
+        self._initialized = False
+
+    async def health_check(self) -> bool:
+        """Return True when the reconstructor can operate."""
+        return fitz is not None
+
+    async def reconstruct(
+        self,
+        file_path: Path,
+        request: ProcessingRequest,
+        content: ProcessingContent,
+    ) -> LayoutReconstructionResult:
+        """Rebuild layout for the requested pages."""
+
+        if fitz is None:
+            raise PDFProcessingError("PyMuPDF is required for layout reconstruction")
+
+        start = time.time()
+        notes: List[str] = []
+
+        doc = fitz.open(str(file_path))
+        try:
+            pages = self._resolve_pages(request.pages, len(doc))
+            reconstructed_pages: List[ReconstructedPage] = []
+
+            for page_index in pages:
+                page = doc[page_index]
+                page_width = float(page.rect.width)
+                page_height = float(page.rect.height)
+
+                text_blocks = self._extract_text_blocks(page)
+                recognized_blocks = self._recognized_blocks_for_page(page, content, page_index + 1)
+                match_map = self._align_text_blocks(text_blocks, recognized_blocks, page_width, page_height)
+
+                if recognized_blocks and len(match_map) < len(text_blocks):
+                    notes.append(
+                        f"Page {page_index + 1}: matched {len(match_map)} of {len(text_blocks)} layout blocks to recognised text; remaining blocks use PDF text."
+                    )
+                elif not recognized_blocks:
+                    notes.append(
+                        f"Page {page_index + 1}: recognised text blocks unavailable; using PDF text only."
+                    )
+
+                elements: List[LayoutElement] = []
+
+                ordered_indices = self._compute_reading_order(text_blocks, page_width, page_height)
+
+                for position, idx in enumerate(ordered_indices):
+                    block = text_blocks[idx]
+                    matched = match_map.get(idx)
+                    block_text = matched.block.text if matched else block.text
+                    if not block_text:
+                        continue
+
+                    spans = matched.block.spans if matched and matched.block.spans else block.spans
+                    lines = matched.block.lines if matched and matched.block.lines else self._build_faux_lines(block)
+                    alignment = matched.block.alignment if matched and matched.block.alignment else block.alignment
+
+                    html_fragment = self._render_text_block(
+                        block_text,
+                        block.bbox,
+                        page_width,
+                        page_height,
+                        spans,
+                        lines,
+                        alignment,
+                        z_index=self._element_z_index(LayoutElementType.TEXT),
+                    )
+                    element = LayoutElement(
+                        element_id=f"text_{page_index + 1}_{idx}",
+                        type=LayoutElementType.TEXT,
+                        bbox=block.bbox,
+                        text=block_text,
+                        html=html_fragment,
+                        metadata={
+                            "font_summary": self._summarize_fonts(block.fonts),
+                            "source": "recognized" if matched else "pdf_layout",
+                            "reading_order": position,
+                        },
+                    )
+                    elements.append(element)
+
+                # Build table elements
+                table_elements = self._render_tables_for_page(
+                    content,
+                    page_index + 1,
+                    page_width,
+                    page_height,
+                    recognized_blocks,
+                    page,
+                )
+                if table_elements:
+                    elements.extend(table_elements)
+
+                # Build formula elements
+                formula_elements = self._render_formulas_for_page(
+                    content,
+                    page_index + 1,
+                    page_width,
+                    page_height,
+                    recognized_blocks,
+                    page,
+                )
+                if formula_elements:
+                    elements.extend(formula_elements)
+
+                elements = self._sort_elements_with_layers(elements)
+
+                page_html = self._compose_page_html(page_index + 1, page_width, page_height, elements)
+                reconstructed_pages.append(
+                    ReconstructedPage(
+                        page_number=page_index + 1,
+                        width=page_width,
+                        height=page_height,
+                        elements=elements,
+                        html=page_html,
+                    )
+                )
+
+            css = self._base_css()
+            processing_time = time.time() - start
+
+            dependency_notes = [
+                "Layout HTML expects MathJax or KaTeX CSS/JS to render formulas (KaTeX stylesheet is referenced via @import).",
+                "For best visual fidelity load document fonts via @font-face or ensure serif fallback fonts are available.",
+            ]
+            for note in dependency_notes:
+                if note not in notes:
+                    notes.append(note)
+
+            return LayoutReconstructionResult(
+                method="pymupdf-layout",
+                processing_time=processing_time,
+                css=css,
+                pages=reconstructed_pages,
+                notes=notes,
+            )
+        finally:
+            doc.close()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _resolve_pages(self, pages: Optional[List[int]], total_pages: int) -> List[int]:
+        if not pages:
+            return list(range(total_pages))
+        resolved: List[int] = []
+        for page in pages:
+            index = max(page - 1, 0)
+            if index < total_pages:
+                resolved.append(index)
+        return resolved
+
+    def _linear_sum_assignment(
+        self, cost_matrix: List[List[float]], filler: float
+    ) -> List[Tuple[int, int]]:
+        """Solve the rectangular assignment problem using the Hungarian algorithm."""
+
+        n_rows = len(cost_matrix)
+        n_cols = max((len(row) for row in cost_matrix), default=0)
+        size = max(n_rows, n_cols)
+        if size == 0:
+            return []
+
+        matrix = [row + [filler] * (size - len(row)) for row in cost_matrix]
+        for _ in range(size - n_rows):
+            matrix.append([filler] * size)
+
+        starred = [[False] * size for _ in range(size)]
+        primed = [[False] * size for _ in range(size)]
+        row_covered = [False] * size
+        col_covered = [False] * size
+
+        # Step 1: subtract row minima
+        for i in range(size):
+            row_min = min(matrix[i])
+            matrix[i] = [val - row_min for val in matrix[i]]
+
+        # Step 2: subtract column minima
+        for j in range(size):
+            col_min = min(matrix[i][j] for i in range(size))
+            for i in range(size):
+                matrix[i][j] -= col_min
+
+        # Step 3: star zeros greedily
+        for i in range(size):
+            for j in range(size):
+                if matrix[i][j] == 0 and not row_covered[i] and not col_covered[j]:
+                    starred[i][j] = True
+                    row_covered[i] = True
+                    col_covered[j] = True
+
+        row_covered = [False] * size
+        col_covered = [False] * size
+
+        def cover_columns_with_starred_zero():
+            for i in range(size):
+                for j in range(size):
+                    if starred[i][j]:
+                        col_covered[j] = True
+
+        cover_columns_with_starred_zero()
+
+        def find_a_zero():
+            for i in range(size):
+                if row_covered[i]:
+                    continue
+                for j in range(size):
+                    if not col_covered[j] and matrix[i][j] == 0:
+                        return i, j
+            return None
+
+        def find_star_in_row(row: int) -> Optional[int]:
+            for j in range(size):
+                if starred[row][j]:
+                    return j
+            return None
+
+        def find_star_in_col(col: int) -> Optional[int]:
+            for i in range(size):
+                if starred[i][col]:
+                    return i
+            return None
+
+        def find_prime_in_row(row: int) -> Optional[int]:
+            for j in range(size):
+                if primed[row][j]:
+                    return j
+            return None
+
+        while sum(col_covered) < size:
+            zero = find_a_zero()
+            while zero is None:
+                # Step 5: adjust matrix
+                uncovered_values = [
+                    matrix[i][j]
+                    for i in range(size)
+                    for j in range(size)
+                    if not row_covered[i] and not col_covered[j]
+                ]
+                min_uncovered = min(uncovered_values)
+                for i in range(size):
+                    for j in range(size):
+                        if row_covered[i]:
+                            matrix[i][j] += min_uncovered
+                        if not col_covered[j]:
+                            matrix[i][j] -= min_uncovered
+                zero = find_a_zero()
+
+            i, j = zero
+            primed[i][j] = True
+            star_col = find_star_in_row(i)
+            if star_col is not None:
+                row_covered[i] = True
+                col_covered[star_col] = False
+            else:
+                # Augmenting path
+                path = [(i, j)]
+                while True:
+                    star_row = find_star_in_col(path[-1][1])
+                    if star_row is None:
+                        break
+                    path.append((star_row, path[-1][1]))
+                    prime_col = find_prime_in_row(star_row)
+                    if prime_col is None:
+                        break
+                    path.append((star_row, prime_col))
+
+                for r, c in path:
+                    starred[r][c] = not starred[r][c]
+                    primed[r][c] = False
+
+                primed = [[False] * size for _ in range(size)]
+                row_covered = [False] * size
+                col_covered = [False] * size
+                cover_columns_with_starred_zero()
+
+        assignments: List[Tuple[int, int]] = []
+        for i in range(n_rows):
+            for j in range(n_cols):
+                if starred[i][j]:
+                    assignments.append((i, j))
+        return assignments
+
+    def _extract_text_blocks(self, page: "fitz.Page") -> List[LayoutBlock]:
+        text_dict = page.get_text("dict")
+        blocks: List[LayoutBlock] = []
+        page_width = float(page.rect.width or 1.0)
+
+        for block in text_dict.get("blocks", []):
+            raw_bbox = block.get("bbox")
+            if not raw_bbox or not block.get("lines"):
+                continue
+
+            normalized_bbox = normalize_bbox(page, raw_bbox)
+
+            lines: List[BoundingBox] = []
+            spans: List[TextSpan] = []
+            fonts: List[Dict[str, Any]] = []
+            line_texts: List[str] = []
+
+            for line in block.get("lines", []):
+                line_bbox = line.get("bbox")
+                if line_bbox:
+                    lines.append(normalize_bbox(page, line_bbox))
+                line_text = []
+                for span in line.get("spans", []):
+                    text_segment = span.get("text", "")
+                    if not text_segment:
+                        continue
+                    fonts.append({"font": span.get("font"), "size": span.get("size")})
+                    spans.append(
+                        TextSpan(
+                            text=text_segment,
+                            font=span.get("font"),
+                            size=span.get("size"),
+                            bold=bool(span.get("flags", 0) & 2),
+                            italic=bool(span.get("flags", 0) & 1),
+                        )
+                    )
+                    line_text.append(text_segment)
+                joined = "".join(line_text).strip()
+                if joined:
+                    line_texts.append(joined)
+
+            combined_text = "\n".join(line_texts).strip()
+            if not combined_text:
+                continue
+
+            alignment = self._infer_alignment(normalized_bbox, page_width)
+            blocks.append(
+                LayoutBlock(
+                    bbox=normalized_bbox,
+                    text=combined_text,
+                    fonts=fonts,
+                    lines=lines,
+                    spans=spans,
+                    alignment=alignment,
+                    line_texts=line_texts,
+                )
+            )
+
+        blocks.sort(key=lambda b: (b.bbox.y0, b.bbox.x0))
+        return blocks
+
+    def _align_text_blocks(
+        self,
+        layout_blocks: List[LayoutBlock],
+        recognized_blocks: List[RecognizedBlock],
+        page_width: float,
+        page_height: float,
+    ) -> Dict[int, RecognizedBlock]:
+        if not layout_blocks or not recognized_blocks:
+            return {}
+
+        cost_matrix: List[List[float]] = []
+        max_cost = 0.0
+        for layout in layout_blocks:
+            diag = math.hypot(layout.bbox.x1 - layout.bbox.x0, layout.bbox.y1 - layout.bbox.y0) or 1.0
+            row: List[float] = []
+            for recognized in recognized_blocks:
+                iou = bbox_iou(layout.bbox, recognized.bbox)
+                distance = bbox_distance(layout.bbox, recognized.bbox)
+                normalized_distance = distance / diag
+                cost = (1.0 - iou) + 0.25 * normalized_distance
+                row.append(cost)
+                if cost > max_cost:
+                    max_cost = cost
+            cost_matrix.append(row)
+
+        assignments = self._linear_sum_assignment(cost_matrix, max_cost + 10.0)
+        matches: Dict[int, RecognizedBlock] = {}
+        for row, col in assignments:
+            if row >= len(layout_blocks) or col >= len(recognized_blocks):
+                continue
+            layout = layout_blocks[row]
+            recognized = recognized_blocks[col]
+            if not self._is_viable_match(layout, recognized):
+                continue
+            matches[row] = recognized
+
+        if matches:
+            self._harmonize_alignment(layout_blocks, matches, page_width, page_height)
+
+        return matches
+
+    def _is_viable_match(self, layout: LayoutBlock, recognized: RecognizedBlock) -> bool:
+        iou = bbox_iou(layout.bbox, recognized.bbox)
+        if iou >= 0.1:
+            return True
+        distance = bbox_distance(layout.bbox, recognized.bbox)
+        diag = math.hypot(layout.bbox.x1 - layout.bbox.x0, layout.bbox.y1 - layout.bbox.y0) or 1.0
+        return distance < diag * 0.7
+
+    def _harmonize_alignment(
+        self,
+        layout_blocks: List[LayoutBlock],
+        matches: Dict[int, RecognizedBlock],
+        page_width: float,
+        page_height: float,
+    ) -> None:
+        if not matches:
+            return
+
+        shifts_x: List[float] = []
+        shifts_y: List[float] = []
+        for idx, recognized in matches.items():
+            layout_bbox = layout_blocks[idx].bbox
+            shifts_x.append(layout_bbox.x0 - recognized.bbox.x0)
+            shifts_y.append(layout_bbox.y0 - recognized.bbox.y0)
+
+        mean_dx = sum(shifts_x) / len(shifts_x)
+        mean_dy = sum(shifts_y) / len(shifts_y)
+
+        if abs(mean_dx) < 0.5 and abs(mean_dy) < 0.5:
+            return
+
+        for match in matches.values():
+            shifted_bbox = self._shift_bbox(match.bbox, mean_dx, mean_dy, page_width, page_height)
+            updated_lines: List[TextLine] = []
+            for line in match.block.lines:
+                if line.bbox:
+                    shifted_line_bbox = self._shift_bbox(line.bbox, mean_dx, mean_dy, page_width, page_height)
+                    updated_lines.append(line.model_copy(update={"bbox": shifted_line_bbox}))
+                else:
+                    updated_lines.append(line)
+            match.block = match.block.model_copy(update={"bbox": shifted_bbox, "lines": updated_lines})
+            match.bbox = shifted_bbox
+
+    def _shift_bbox(
+        self,
+        bbox: BoundingBox,
+        dx: float,
+        dy: float,
+        page_width: float,
+        page_height: float,
+    ) -> BoundingBox:
+        x0 = min(max(bbox.x0 + dx, 0.0), page_width)
+        y0 = min(max(bbox.y0 + dy, 0.0), page_height)
+        x1 = min(max(bbox.x1 + dx, 0.0), page_width)
+        y1 = min(max(bbox.y1 + dy, 0.0), page_height)
+        if x1 <= x0:
+            x1 = min(page_width, x0 + 0.5)
+        if y1 <= y0:
+            y1 = min(page_height, y0 + 0.5)
+        return BoundingBox(x0=x0, y0=y0, x1=x1, y1=y1)
+
+    def _compute_reading_order(
+        self,
+        blocks: List[LayoutBlock],
+        page_width: float,
+        page_height: float,
+    ) -> List[int]:
+        if not blocks:
+            return []
+
+        columns: List[List[int]] = []
+        footnotes: List[int] = []
+        column_threshold = max(page_width * 0.12, 36.0)
+
+        for idx, block in enumerate(blocks):
+            if self._is_footnote(block, page_height):
+                footnotes.append(idx)
+                continue
+
+            placed = False
+            for column in columns:
+                ref = blocks[column[0]]
+                if abs(block.bbox.x0 - ref.bbox.x0) <= column_threshold:
+                    column.append(idx)
+                    placed = True
+                    break
+            if not placed:
+                columns.append([idx])
+
+        columns.sort(key=lambda col: min(blocks[i].bbox.x0 for i in col))
+        ordered: List[int] = []
+        for column in columns:
+            column.sort(key=lambda i: blocks[i].bbox.y0)
+            ordered.extend(column)
+
+        footnotes.sort(key=lambda i: blocks[i].bbox.y0)
+        ordered.extend(footnotes)
+
+        if not ordered:
+            ordered = list(range(len(blocks)))
+        return ordered
+
+    def _is_footnote(self, block: LayoutBlock, page_height: float) -> bool:
+        height = block.bbox.y1 - block.bbox.y0
+        return block.bbox.y0 > page_height * 0.82 and height < page_height * 0.18 and len(block.line_texts) <= 3
+
+    def _build_faux_lines(self, block: LayoutBlock) -> List[TextLine]:
+        if block.lines and block.line_texts:
+            return [
+                TextLine(text=text, bbox=bbox, spans=[])
+                for text, bbox in zip(block.line_texts, block.lines)
+            ]
+        return [TextLine(text=block.text, bbox=block.bbox, spans=[])]
+
+    def _element_z_index(self, element_type: LayoutElementType) -> int:
+        mapping = {
+            LayoutElementType.TEXT: 10,
+            LayoutElementType.TABLE: 30,
+            LayoutElementType.FORMULA: 40,
+            LayoutElementType.IMAGE: 20,
+            LayoutElementType.OTHER: 5,
+        }
+        return mapping.get(element_type, 1)
+
+    def _sort_elements_with_layers(self, elements: List[LayoutElement]) -> List[LayoutElement]:
+        return sorted(
+            elements,
+            key=lambda el: (
+                self._element_z_index(el.type),
+                el.metadata.get("reading_order", 0) if isinstance(el.metadata, dict) else 0,
+                el.bbox.y0,
+                el.bbox.x0,
+            ),
+        )
+
+    def _recognized_blocks_for_page(
+        self,
+        page: "fitz.Page",
+        content: ProcessingContent,
+        page_number: int,
+    ) -> List[RecognizedBlock]:
+        if not content or not content.text:
+            return []
+
+        for page_text in content.text.pages:
+            if page_text.page != page_number:
+                continue
+
+            recognized: List[RecognizedBlock] = []
+            for block in page_text.blocks:
+                if not block.bbox:
+                    continue
+                normalized_bbox = normalize_bbox(page, block.bbox)
+                normalized_lines: List[TextLine] = []
+                for line in block.lines:
+                    if line.bbox:
+                        normalized_line = line.model_copy(
+                            update={
+                                "bbox": normalize_bbox(page, line.bbox),
+                            }
+                        )
+                    else:
+                        normalized_line = line
+                    normalized_lines.append(normalized_line)
+
+                block_copy = block.model_copy(
+                    update={
+                        "bbox": normalized_bbox,
+                        "lines": normalized_lines,
+                    }
+                )
+                recognized.append(RecognizedBlock(block=block_copy, bbox=normalized_bbox))
+            return recognized
+
+        return []
+
+    def _render_text_block(
+        self,
+        text: str,
+        bbox: BoundingBox,
+        page_width: float,
+        page_height: float,
+        spans: Iterable[TextSpan],
+        lines: Iterable[TextLine],
+        alignment: Optional[str],
+        *,
+        z_index: Optional[int] = None,
+    ) -> str:
+        style = self._bbox_to_style(bbox, page_width, page_height, z_index=z_index)
+        alignment_style = f"text-align:{alignment};" if alignment else ""
+        content = self._render_lines(list(lines), list(spans), text)
+        return f'<div class="pdf-block pdf-block-text" style="{style}{alignment_style}">{content}</div>'
+
+    def _render_lines(
+        self,
+        lines: List[TextLine],
+        spans: List[TextSpan],
+        fallback_text: str,
+    ) -> str:
+        if lines:
+            fragments: List[str] = []
+            for line in lines:
+                fragments.append(
+                    '<div class="pdf-line">'
+                    + self._render_span_sequence(line.spans, line.text)
+                    + "</div>"
+                )
+            return "".join(fragments)
+        return self._render_span_sequence(spans, fallback_text)
+
+    def _render_span_sequence(self, spans: List[TextSpan], fallback_text: str) -> str:
+        if not spans:
+            return html.escape(fallback_text).replace("\n", "<br />")
+
+        pieces: List[str] = []
+        for span in spans:
+            if not span.text:
+                continue
+            style_bits: List[str] = []
+            if span.size:
+                style_bits.append(f"font-size:{span.size:.1f}px;")
+            if span.font:
+                style_bits.append(f"font-family:'{span.font}', sans-serif;")
+            if span.bold:
+                style_bits.append("font-weight:bold;")
+            if span.italic:
+                style_bits.append("font-style:italic;")
+            style_attr = f" style=\"{''.join(style_bits)}\"" if style_bits else ""
+            pieces.append(f"<span{style_attr}>{html.escape(span.text)}</span>")
+        return "".join(pieces) if pieces else html.escape(fallback_text)
+
+    def _normalize_or_fallback_bbox(
+        self,
+        page: "fitz.Page",
+        bbox: BoundingBox,
+        page_width: float,
+        page_height: float,
+        recognized_blocks: List[RecognizedBlock],
+        tokens: Iterable[Optional[str]],
+    ) -> BoundingBox:
+        candidate = bbox
+        if candidate:
+            try:
+                candidate = normalize_bbox(page, candidate)
+            except Exception:  # pragma: no cover - defensive
+                candidate = bbox
+
+        if not candidate or self._is_degenerate(candidate):
+            fallback = self._fallback_bbox_from_text(recognized_blocks, tokens)
+            if fallback:
+                candidate = fallback
+
+        if not candidate:
+            candidate = BoundingBox(x0=0.0, y0=0.0, x1=page_width, y1=page_height / 6)
+
+        return BoundingBox(
+            x0=min(max(candidate.x0, 0.0), page_width),
+            y0=min(max(candidate.y0, 0.0), page_height),
+            x1=min(max(candidate.x1, 0.0), page_width),
+            y1=min(max(candidate.y1, 0.0), page_height),
+        )
+
+    def _is_degenerate(self, bbox: BoundingBox) -> bool:
+        return (bbox.x1 - bbox.x0) * (bbox.y1 - bbox.y0) < 1.0
+
+    def _fallback_bbox_from_text(
+        self,
+        recognized_blocks: List[RecognizedBlock],
+        tokens: Iterable[Optional[str]],
+    ) -> Optional[BoundingBox]:
+        cleaned_tokens = [token.strip() for token in tokens if token]
+        if not cleaned_tokens:
+            return None
+
+        matched_boxes: List[BoundingBox] = []
+        for candidate in recognized_blocks:
+            text = candidate.block.text.replace("\n", " ") if candidate.block.text else ""
+            for token in cleaned_tokens:
+                if token and token in text:
+                    matched_boxes.append(candidate.bbox)
+                    break
+
+        if not matched_boxes:
+            return None
+
+        x0 = min(box.x0 for box in matched_boxes)
+        y0 = min(box.y0 for box in matched_boxes)
+        x1 = max(box.x1 for box in matched_boxes)
+        y1 = max(box.y1 for box in matched_boxes)
+        return BoundingBox(x0=x0, y0=y0, x1=x1, y1=y1)
+
+    def _render_tables_for_page(
+        self,
+        content: ProcessingContent,
+        page_number: int,
+        page_width: float,
+        page_height: float,
+        recognized_blocks: List[RecognizedBlock],
+        page: "fitz.Page",
+    ) -> List[LayoutElement]:
+        if not content.tables:
+            return []
+
+        table_elements: List[LayoutElement] = []
+        for table in content.tables.tables:
+            if table.page != page_number:
+                continue
+            html_table = self._table_to_html(table)
+            bbox = self._normalize_or_fallback_bbox(
+                page,
+                table.bbox,
+                page_width,
+                page_height,
+                recognized_blocks,
+                [table.headers[0]] if table.headers else table.data[0] if table.data else [],
+            )
+            wrapped = self._wrap_absolute(
+                bbox,
+                page_width,
+                page_height,
+                html_table,
+                "pdf-block-table",
+                z_index=self._element_z_index(LayoutElementType.TABLE),
+            )
+            table_elements.append(
+                LayoutElement(
+                    element_id=f"table_{page_number}_{table.table_id}",
+                    type=LayoutElementType.TABLE,
+                    bbox=bbox,
+                    text=None,
+                    html=wrapped,
+                    metadata={
+                        "engine": table.engine,
+                        "confidence": table.confidence,
+                        "rows": table.rows,
+                        "columns": table.columns,
+                    },
+                )
+            )
+        return table_elements
+
+    def _render_formulas_for_page(
+        self,
+        content: ProcessingContent,
+        page_number: int,
+        page_width: float,
+        page_height: float,
+        recognized_blocks: List[RecognizedBlock],
+        page: "fitz.Page",
+    ) -> List[LayoutElement]:
+        if not content.formulas:
+            return []
+
+        elements: List[LayoutElement] = []
+        for formula in content.formulas.formulas:
+            if formula.page != page_number:
+                continue
+            latex = html.escape(formula.latex)
+            span = f'<span class="pdf-formula" data-latex="{latex}">\\({latex}\\)</span>'
+            bbox = self._normalize_or_fallback_bbox(
+                page,
+                formula.bbox,
+                page_width,
+                page_height,
+                recognized_blocks,
+                [formula.raw_text] if getattr(formula, "raw_text", None) else [formula.latex],
+            )
+            wrapped = self._wrap_absolute(
+                bbox,
+                page_width,
+                page_height,
+                span,
+                "pdf-block-formula",
+                z_index=self._element_z_index(LayoutElementType.FORMULA),
+            )
+            elements.append(
+                LayoutElement(
+                    element_id=f"formula_{page_number}_{formula.formula_id}",
+                    type=LayoutElementType.FORMULA,
+                    bbox=bbox,
+                    text=formula.latex,
+                    html=wrapped,
+                    metadata={
+                        "confidence": formula.confidence,
+                        "model": formula.model,
+                    },
+                )
+            )
+        return elements
+
+    def _table_to_html(self, table: TableData) -> str:
+        rows_html: List[str] = []
+        for row in table.data:
+            cells = "".join(f"<td>{html.escape(cell)}</td>" for cell in row)
+            rows_html.append(f"<tr>{cells}</tr>")
+        header_html = ""
+        if table.headers:
+            header_cells = "".join(f"<th>{html.escape(cell)}</th>" for cell in table.headers)
+            header_html = f"<thead><tr>{header_cells}</tr></thead>"
+        body_html = "<tbody>" + "".join(rows_html) + "</tbody>"
+        return f"<table class=\"pdf-table\">{header_html}{body_html}</table>"
+
+    def _wrap_absolute(
+        self,
+        bbox: BoundingBox,
+        page_width: float,
+        page_height: float,
+        inner_html: str,
+        extra_class: str,
+        *,
+        z_index: Optional[int] = None,
+    ) -> str:
+        style = self._bbox_to_style(bbox, page_width, page_height, z_index=z_index)
+        return f'<div class="pdf-block {extra_class}" style="{style}">{inner_html}</div>'
+
+    def _compose_page_html(
+        self,
+        page_number: int,
+        page_width: float,
+        page_height: float,
+        elements: List[LayoutElement],
+    ) -> str:
+        joined = "\n".join(element.html for element in elements)
+        return (
+            f'<section class="pdf-page" data-page="{page_number}" '
+            f'style="width:{page_width}px;height:{page_height}px;">\n{joined}\n</section>'
+        )
+
+    def _bbox_to_style(
+        self,
+        bbox: BoundingBox,
+        page_width: float,
+        page_height: float,
+        *,
+        z_index: Optional[int] = None,
+    ) -> str:
+        if page_width == 0 or page_height == 0:
+            return ""
+        left = (bbox.x0 / page_width) * 100
+        top = (bbox.y0 / page_height) * 100
+        width = max((bbox.x1 - bbox.x0) / page_width * 100, 0.1)
+        height = max((bbox.y1 - bbox.y0) / page_height * 100, 0.1)
+        pieces = [
+            f"left:{left:.3f}%;",
+            f"top:{top:.3f}%;",
+            f"width:{width:.3f}%;",
+            f"height:{height:.3f}%;",
+        ]
+        if z_index is not None:
+            pieces.append(f"z-index:{z_index};")
+        return "".join(pieces)
+
+    def _summarize_fonts(self, fonts: Iterable[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        fonts = [font for font in fonts if font.get("font")]
+        if not fonts:
+            return None
+        families = Counter(font.get("font") for font in fonts if font.get("font"))
+        sizes = [font.get("size") for font in fonts if isinstance(font.get("size"), (int, float))]
+        summary: Dict[str, Any] = {
+            "primary_font": families.most_common(1)[0][0] if families else None,
+            "font_count": len(families),
+        }
+        if sizes:
+            summary.update(
+                {
+                    "average_size": sum(sizes) / len(sizes),
+                    "min_size": min(sizes),
+                    "max_size": max(sizes),
+                }
+            )
+        return summary
+
+    def _base_css(self) -> str:
+        return """
+@import url('https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css');
+
+.pdf-page {
+  position: relative;
+  margin: 1rem auto;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.15);
+  background: #fff;
+  font-family: 'Noto Serif', 'Times New Roman', serif;
+}
+
+.pdf-block {
+  position: absolute;
+  overflow: hidden;
+  white-space: normal;
+}
+
+.pdf-block-text {
+  line-height: 1.35;
+  color: #222;
+  word-break: break-word;
+}
+
+.pdf-line {
+  width: 100%;
+}
+
+.pdf-line span {
+  display: inline;
+}
+
+.pdf-block-table {
+  background: rgba(255, 255, 255, 0.95);
+}
+
+.pdf-block-table table {
+  border-collapse: collapse;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.95);
+}
+
+.pdf-block-table th,
+.pdf-block-table td {
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  padding: 0.2rem 0.3rem;
+  font-size: 0.9em;
+}
+
+.pdf-block-formula {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pdf-formula {
+  font-family: "Times New Roman", serif;
+  font-size: 1em;
+}
+"""
+

--- a/MCP/PDF/src/pdf_mcp_server/processors/pdf_processor.py
+++ b/MCP/PDF/src/pdf_mcp_server/processors/pdf_processor.py
@@ -26,6 +26,7 @@ from typing import Dict, Any, Optional  # 类型注解
 import uuid     # 唯一标识符生成
 
 # 数据模型导入
+from .. import __version__
 from ..models import (
     ProcessingRequest,    # 处理请求模型
     ProcessingResponse,   # 处理响应模型
@@ -43,6 +44,7 @@ from .text_extractor import TextExtractor          # 文本提取器
 from .table_extractor import TableExtractor        # 表格提取器
 from .ocr_processor import OCRProcessor            # OCR处理器
 from .formula_extractor import FormulaExtractor    # 公式提取器
+from .layout_reconstructor import LayoutReconstructor  # 版面重建器
 
 
 class PDFProcessor:
@@ -91,6 +93,7 @@ class PDFProcessor:
         self.table_extractor: Optional[TableExtractor] = None     # 表格提取器
         self.ocr_processor: Optional[OCRProcessor] = None         # OCR处理器
         self.formula_extractor: Optional[FormulaExtractor] = None # 公式提取器
+        self.layout_reconstructor: Optional[LayoutReconstructor] = None  # 版面重建器
         
         # 处理统计信息
         self.total_processed = 0  # 已处理文档总数
@@ -129,7 +132,11 @@ class PDFProcessor:
             # 初始化公式提取器
             self.formula_extractor = FormulaExtractor(self.config)
             await self.formula_extractor.initialize()
-            
+
+            # 初始化版面重建器
+            self.layout_reconstructor = LayoutReconstructor(self.config)
+            await self.layout_reconstructor.initialize()
+
             self.logger.info("PDF处理器初始化成功")
             
         except Exception as e:
@@ -151,7 +158,8 @@ class PDFProcessor:
             self.text_extractor,     # 文本提取器
             self.table_extractor,    # 表格提取器
             self.ocr_processor,      # OCR处理器
-            self.formula_extractor   # 公式提取器
+            self.formula_extractor,  # 公式提取器
+            self.layout_reconstructor  # 版面重建器
         ]
         
         # 逐个清理处理器资源
@@ -183,7 +191,8 @@ class PDFProcessor:
             "text_extractor": self.text_extractor,          # 文本提取器
             "table_extractor": self.table_extractor,        # 表格提取器
             "ocr_processor": self.ocr_processor,            # OCR处理器
-            "formula_extractor": self.formula_extractor     # 公式提取器
+            "formula_extractor": self.formula_extractor,    # 公式提取器
+            "layout_reconstructor": self.layout_reconstructor  # 版面重建器
         }
         
         # 逐个检查处理器健康状态
@@ -248,8 +257,9 @@ class PDFProcessor:
             processing_time = time.time() - start_time  # 计算处理耗时
             metadata = ProcessingMetadata(
                 processing_time=processing_time,
-                engines_used=processing_plan["engines_used"],
-                file_info=pdf_info
+                engines_used=list(dict.fromkeys(processing_plan["engines_used"])),
+                file_info=pdf_info,
+                version=__version__,
             )
             
             # 更新统计信息
@@ -365,7 +375,8 @@ class PDFProcessor:
             "extract_text": False,         # 是否提取文本
             "extract_tables": False,       # 是否提取表格
             "extract_formulas": False,     # 是否提取公式
-            "use_grobid": False           # 是否使用GROBID
+            "use_grobid": False,          # 是否使用GROBID
+            "reconstruct_layout": False   # 是否执行版面重建
         }
         
         # 判断是否需要OCR处理
@@ -378,23 +389,47 @@ class PDFProcessor:
         if request.mode in [ProcessingMode.TEXT, ProcessingMode.FULL]:
             plan["extract_text"] = True
             plan["steps"].append("text_extraction")
-            plan["engines_used"].extend(["pymupdf", "pdfplumber"])
-        
+            for engine in ["pymupdf", "pdfplumber"]:
+                if engine not in plan["engines_used"]:
+                    plan["engines_used"].append(engine)
+
         if request.mode in [ProcessingMode.TABLES, ProcessingMode.FULL]:
             plan["extract_tables"] = True
             plan["steps"].append("table_extraction")
-            plan["engines_used"].extend(["camelot", "tabula"])
-        
-        if request.mode in [ProcessingMode.FORMULAS, ProcessingMode.FULL] and request.include_formulas:
+            for engine in ["camelot", "tabula"]:
+                if engine not in plan["engines_used"]:
+                    plan["engines_used"].append(engine)
+
+        if (
+            request.mode in [ProcessingMode.FORMULAS, ProcessingMode.FULL]
+            and request.include_formulas
+        ):
             plan["extract_formulas"] = True
             plan["steps"].append("formula_extraction")
-            plan["engines_used"].append(str(request.formula_model))
-        
+            engine_name = str(request.formula_model)
+            if engine_name not in plan["engines_used"]:
+                plan["engines_used"].append(engine_name)
+
         if request.include_grobid:
             plan["use_grobid"] = True
             plan["steps"].append("grobid_parsing")
-            plan["engines_used"].append("grobid")
-        
+            if "grobid" not in plan["engines_used"]:
+                plan["engines_used"].append("grobid")
+
+        if request.reconstruct_layout:
+            plan["reconstruct_layout"] = True
+            if not plan["extract_text"]:
+                plan["extract_text"] = True
+                plan["steps"].append("text_extraction")
+                for engine in ["pymupdf", "pdfplumber"]:
+                    if engine not in plan["engines_used"]:
+                        plan["engines_used"].append(engine)
+            plan["steps"].append("layout_reconstruction")
+            if "layout_reconstructor" not in plan["engines_used"]:
+                plan["engines_used"].append("layout_reconstructor")
+            if not request.include_bbox:
+                plan["force_bbox"] = True
+
         return plan
     
     async def _execute_processing(self, file_path: Path, plan: Dict[str, Any], request: ProcessingRequest) -> ProcessingContent:
@@ -421,7 +456,10 @@ class PDFProcessor:
         # 提取文本内容
         if plan["extract_text"]:
             self.logger.info("正在提取文本")
-            content.text = await self.text_extractor.extract(file_path, request)
+            text_request = request
+            if plan.get("force_bbox") and not request.include_bbox:
+                text_request = request.model_copy(update={"include_bbox": True})
+            content.text = await self.text_extractor.extract(file_path, text_request)
         
         # 提取表格数据
         if plan["extract_tables"]:
@@ -432,7 +470,14 @@ class PDFProcessor:
         if plan["extract_formulas"]:
             self.logger.info("正在提取公式")
             content.formulas = await self.formula_extractor.extract(file_path, request)
-        
+
+        # 版面重建
+        if plan.get("reconstruct_layout"):
+            if not self.layout_reconstructor:
+                raise PDFProcessingError("Layout reconstructor not initialized")
+            self.logger.info("正在执行版面重建")
+            content.layout = await self.layout_reconstructor.reconstruct(file_path, request, content)
+
         # GROBID学术文档处理
         if plan["use_grobid"]:
             self.logger.info("正在使用GROBID处理")

--- a/MCP/PDF/src/pdf_mcp_server/processors/text_extractor.py
+++ b/MCP/PDF/src/pdf_mcp_server/processors/text_extractor.py
@@ -25,7 +25,10 @@ from ..models import (
     TextExtractionResult,
     PageText,
     BoundingBox,
-    OutputFormat
+    OutputFormat,
+    TextBlock,
+    TextLine,
+    TextSpan,
 )
 from ..utils.config import Config
 from ..utils.exceptions import PDFProcessingError
@@ -175,41 +178,81 @@ class TextExtractor:
         """
         # Get text with detailed information
         text_dict = page.get_text("dict")
-        
-        text_blocks = []
+
+        blocks = []
         full_text = ""
-        
+
         for block in text_dict.get("blocks", []):
-            if "lines" in block:  # Text block
-                block_text = ""
-                block_bbox = block["bbox"]
-                
-                for line in block["lines"]:
-                    line_text = ""
-                    for span in line["spans"]:
-                        line_text += span["text"]
-                    
-                    if line_text.strip():
-                        block_text += line_text + "\n"
-                
-                if block_text.strip():
-                    text_blocks.append({
-                        "text": block_text.strip(),
-                        "bbox": BoundingBox(
-                            x0=block_bbox[0],
-                            y0=block_bbox[1],
-                            x1=block_bbox[2],
-                            y1=block_bbox[3]
-                        ),
-                        "font_info": self._extract_font_info(block)
-                    })
-                    full_text += block_text
-        
-        # Map to models.PageText fields
+            if "lines" not in block:
+                continue
+
+            block_text_parts = []
+            block_lines = []
+            block_spans = []
+            for line in block.get("lines", []):
+                line_text_parts = []
+                line_spans = []
+                for span in line.get("spans", []):
+                    span_text = span.get("text", "")
+                    if not span_text:
+                        continue
+                    style = TextSpan(
+                        text=span_text,
+                        font=span.get("font"),
+                        size=span.get("size"),
+                        bold=bool(span.get("flags", 0) & 2),
+                        italic=bool(span.get("flags", 0) & 1),
+                    )
+                    line_spans.append(style)
+                    block_spans.append(style)
+                    line_text_parts.append(span_text)
+
+                line_text = "".join(line_text_parts).strip()
+                if not line_text:
+                    continue
+
+                line_bbox = line.get("bbox")
+                block_lines.append(
+                    TextLine(
+                        text=line_text,
+                        bbox=BoundingBox(
+                            x0=line_bbox[0],
+                            y0=line_bbox[1],
+                            x1=line_bbox[2],
+                            y1=line_bbox[3],
+                        ) if line_bbox else None,
+                        spans=line_spans,
+                    )
+                )
+                block_text_parts.append(line_text)
+
+            combined_text = "\n".join(block_text_parts).strip()
+            if not combined_text:
+                continue
+
+            block_bbox = block.get("bbox")
+            bbox = BoundingBox(
+                x0=block_bbox[0],
+                y0=block_bbox[1],
+                x1=block_bbox[2],
+                y1=block_bbox[3],
+            ) if block_bbox else BoundingBox(x0=0, y0=0, x1=0, y1=0)
+
+            blocks.append(
+                TextBlock(
+                    text=combined_text,
+                    bbox=bbox,
+                    lines=block_lines,
+                    spans=block_spans,
+                )
+            )
+            full_text += combined_text + "\n\n"
+
         return PageText(
             page=page_num + 1,
             text=full_text.strip(),
-            bbox=None,
+            bbox=[block.bbox for block in blocks] if blocks else None,
+            blocks=blocks,
             confidence=None,
             language=None,
         )
@@ -296,57 +339,84 @@ class TextExtractor:
         """
         # Get characters with positions
         chars = page.chars
-        
-        # Group characters into words and lines
-        text_blocks = []
+
+        blocks: List[TextBlock] = []
         full_text = ""
-        
+
         if chars:
-            # Simple grouping by proximity
-            current_line = []
+            current_line: List[Dict[str, Any]] = []
             current_y = None
-            
+            current_block_lines: List[TextLine] = []
+
+            def _flush_line() -> Optional[TextLine]:
+                nonlocal current_line
+                if not current_line:
+                    return None
+                line_text = ''.join([c['text'] for c in current_line]).strip()
+                if not line_text:
+                    current_line = []
+                    return None
+                bbox = self._get_line_bbox(current_line)
+                spans = [
+                    TextSpan(
+                        text=c.get('text', ''),
+                        font=c.get('fontname'),
+                        size=c.get('size'),
+                        bold='Bold' in (c.get('fontname') or ''),
+                        italic='Italic' in (c.get('fontname') or ''),
+                    )
+                    for c in current_line
+                    if c.get('text')
+                ]
+                line = TextLine(text=line_text, bbox=bbox, spans=spans)
+                current_line = []
+                return line
+
             for char in chars:
-                if current_y is None or abs(char['y0'] - current_y) < 5:  # Same line
+                if current_y is None or abs(char['y0'] - current_y) < 5:
                     current_line.append(char)
                     current_y = char['y0']
                 else:
-                    # Process current line
-                    if current_line:
-                        line_text = ''.join([c['text'] for c in current_line])
-                        if line_text.strip():
-                            bbox = self._get_line_bbox(current_line)
-                            text_blocks.append({
-                                "text": line_text.strip(),
-                                "bbox": bbox,
-                                "font_info": self._get_font_info_pdfplumber(current_line)
-                            })
-                            full_text += line_text.strip() + "\n"
-                    
-                    # Start new line
+                    line_model = _flush_line()
+                    if line_model:
+                        current_block_lines.append(line_model)
+                        full_text += line_model.text + "\n"
                     current_line = [char]
                     current_y = char['y0']
-            
-            # Process last line
-            if current_line:
-                line_text = ''.join([c['text'] for c in current_line])
-                if line_text.strip():
-                    bbox = self._get_line_bbox(current_line)
-                    text_blocks.append({
-                        "text": line_text.strip(),
-                        "bbox": bbox,
-                        "font_info": self._get_font_info_pdfplumber(current_line)
-                    })
-                    full_text += line_text.strip() + "\n"
-        
-        # Fallback to simple extraction if character-level fails
-        if not full_text.strip():
-            full_text = page.extract_text() or ""
-        
+
+            line_model = _flush_line()
+            if line_model:
+                current_block_lines.append(line_model)
+                full_text += line_model.text + "\n"
+
+            if current_block_lines:
+                combined_text = "\n".join(line.text for line in current_block_lines).strip()
+                bbox = self._get_line_bbox(chars)
+                blocks.append(
+                    TextBlock(
+                        text=combined_text,
+                        bbox=bbox,
+                        lines=current_block_lines,
+                        spans=[span for line in current_block_lines for span in line.spans],
+                    )
+                )
+
+        if not blocks:
+            text = (page.extract_text() or "").strip()
+            return PageText(
+                page=page_num + 1,
+                text=text,
+                bbox=None,
+                blocks=[],
+                confidence=None,
+                language=None,
+            )
+
         return PageText(
             page=page_num + 1,
-            text=full_text.strip(),
-            bbox=None,
+            text=(full_text or "").strip(),
+            bbox=[block.bbox for block in blocks],
+            blocks=blocks,
             confidence=None,
             language=None,
         )

--- a/MCP/PDF/src/pdf_mcp_server/tools/__init__.py
+++ b/MCP/PDF/src/pdf_mcp_server/tools/__init__.py
@@ -15,6 +15,7 @@ from .ocr_processing import ProcessOCRTool, OCRWithLayoutTool
 from .formula_recognition import ExtractFormulasTool, FormulaToLatexTool
 from .pdf_analysis import AnalyzePDFTool, DetectPDFTypeTool
 from .full_pipeline import FullPipelineTool, SmartProcessingTool
+from .layout_reconstruction import ReconstructLayoutTool
 
 # Tool classes for easy import
 __all__ = [
@@ -41,7 +42,10 @@ __all__ = [
     # Pipeline tools
     "FullPipelineTool",
     "SmartProcessingTool",
-    
+
+    # Layout tools
+    "ReconstructLayoutTool",
+
     # Utility functions
     "register_all_tools",
     "get_available_tools",
@@ -55,7 +59,8 @@ TOOL_CATEGORIES = {
     "ocr": ["ProcessOCRTool", "OCRWithLayoutTool"],
     "formula": ["ExtractFormulasTool", "FormulaToLatexTool"],
     "analysis": ["AnalyzePDFTool", "DetectPDFTypeTool"],
-    "pipeline": ["FullPipelineTool", "SmartProcessingTool"]
+    "pipeline": ["FullPipelineTool", "SmartProcessingTool"],
+    "layout": ["ReconstructLayoutTool"],
 }
 
 TOOL_DESCRIPTIONS = {
@@ -70,7 +75,8 @@ TOOL_DESCRIPTIONS = {
     "AnalyzePDFTool": "Analyze PDF structure, content types, and characteristics",
     "DetectPDFTypeTool": "Detect the type and category of PDF document",
     "FullPipelineTool": "Complete PDF processing pipeline with all features",
-    "SmartProcessingTool": "Intelligent PDF processing with automatic feature detection"
+    "SmartProcessingTool": "Intelligent PDF processing with automatic feature detection",
+    "ReconstructLayoutTool": "Rebuild PDF layout using extracted content to mimic the original formatting"
 }
 
 
@@ -117,7 +123,10 @@ def create_tool_instances():
     # Pipeline tools
     tools.append(FullPipelineTool())
     tools.append(SmartProcessingTool())
-    
+
+    # Layout tools
+    tools.append(ReconstructLayoutTool())
+
     return tools
 
 

--- a/MCP/PDF/src/pdf_mcp_server/tools/layout_reconstruction.py
+++ b/MCP/PDF/src/pdf_mcp_server/tools/layout_reconstruction.py
@@ -1,0 +1,185 @@
+"""Tools for reconstructing PDF layout."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ..mcp.tools import PDFTool
+from ..mcp.protocol import MCPToolResult, create_error_content, create_text_content
+from ..mcp.exceptions import ToolExecutionException
+from ..models import FormulaModel, ProcessingMode, ProcessingRequest, TableEngine
+from ..processors.pdf_processor import PDFProcessor
+from ..utils.config import Config
+
+
+class ReconstructLayoutTool(PDFTool):
+    """High-level MCP tool for PDF layout reconstruction."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="reconstruct_layout",
+            description="Rebuild PDF layout using extracted text, tables, and formulas",
+        )
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+
+    def get_input_schema(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Path to the PDF file",
+                },
+                "pages": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "description": "Specific pages to process (1-indexed)",
+                },
+                "include_ocr": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "Allow OCR for scanned documents",
+                },
+                "include_tables": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "Extract tables for layout placement",
+                },
+                "include_formulas": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "Extract formulas for layout placement",
+                },
+                "table_engine": {
+                    "type": "string",
+                    "enum": [engine.value for engine in TableEngine],
+                    "default": TableEngine.CAMELOT.value,
+                    "description": "Primary table extraction engine",
+                },
+                "formula_model": {
+                    "type": "string",
+                    "enum": [model.value for model in FormulaModel],
+                    "default": FormulaModel.LATEX_OCR.value,
+                    "description": "Formula recognition model",
+                },
+                "output": {
+                    "type": "string",
+                    "enum": ["summary", "json", "html", "all"],
+                    "default": "all",
+                    "description": "Output format preference",
+                },
+            },
+            "required": ["file_path"],
+        }
+
+    @property
+    def input_schema(self):  # type: ignore[override]
+        from pydantic import BaseModel, Field
+        from typing import List, Optional
+
+        class LayoutInput(BaseModel):
+            file_path: str = Field(description="Path to the PDF file")
+            pages: Optional[List[int]] = Field(default=None, description="Pages to process (1-indexed)")
+            include_ocr: bool = Field(default=True, description="Allow OCR when necessary")
+            include_tables: bool = Field(default=True, description="Extract tables for placement")
+            include_formulas: bool = Field(default=True, description="Extract formulas for placement")
+            table_engine: str = Field(default=TableEngine.CAMELOT.value, description="Table extraction engine")
+            formula_model: str = Field(default=FormulaModel.LATEX_OCR.value, description="Formula recognition model")
+            output: str = Field(default="all", description="Preferred output format")
+
+        return LayoutInput
+
+    @property
+    def output_schema(self):  # type: ignore[override]
+        from pydantic import BaseModel, Field
+        from typing import Any, Dict, Optional
+
+        class LayoutOutput(BaseModel):
+            success: bool = Field(description="Whether reconstruction succeeded")
+            message: Optional[str] = Field(default=None, description="Status message")
+            result: Optional[Dict[str, Any]] = Field(default=None, description="Layout reconstruction payload")
+
+        return LayoutOutput
+
+    async def execute(self, **kwargs) -> MCPToolResult:
+        try:
+            pdf_path = self.validate_file_path(kwargs["file_path"])
+        except Exception as exc:  # pragma: no cover - validation path
+            return MCPToolResult(
+                content=[create_error_content(f"Invalid file path: {exc}")],
+                isError=True,
+            )
+
+        pages = kwargs.get("pages")
+        include_ocr = kwargs.get("include_ocr", True)
+        include_tables = kwargs.get("include_tables", True)
+        include_formulas = kwargs.get("include_formulas", True)
+        table_engine_value = kwargs.get("table_engine", TableEngine.CAMELOT.value)
+        formula_model_value = kwargs.get("formula_model", FormulaModel.LATEX_OCR.value)
+        output_mode = kwargs.get("output", "all")
+
+        try:
+            table_engine = TableEngine(table_engine_value)
+        except Exception as exc:  # pragma: no cover - enum validation
+            raise ToolExecutionException(f"Unsupported table engine: {table_engine_value}") from exc
+
+        try:
+            formula_model = FormulaModel(formula_model_value)
+        except Exception as exc:  # pragma: no cover - enum validation
+            raise ToolExecutionException(f"Unsupported formula model: {formula_model_value}") from exc
+
+        config = Config.load()
+        processor = PDFProcessor(config)
+        await processor.initialize()
+        try:
+            mode = ProcessingMode.FULL if (include_tables or include_formulas) else ProcessingMode.TEXT
+            request = ProcessingRequest(
+                file_path=str(pdf_path),
+                mode=mode,
+                pages=pages,
+                include_ocr=include_ocr,
+                include_formulas=include_formulas,
+                table_engine=table_engine,
+                formula_model=formula_model,
+                reconstruct_layout=True,
+            )
+            result = await processor.process(request)
+        except Exception as exc:
+            self.logger.error("Layout reconstruction failed: %s", exc, exc_info=True)
+            await processor.cleanup()
+            return MCPToolResult(
+                content=[create_error_content(f"Layout reconstruction failed: {exc}")],
+                isError=True,
+            )
+
+        await processor.cleanup()
+
+        layout = result.content.layout if result and result.content else None
+        if not layout:
+            return MCPToolResult(
+                content=[create_error_content("Layout reconstruction returned no result")],
+                isError=True,
+            )
+
+        content: List[Dict[str, Any]] = []
+        summary = (
+            f"Reconstructed {len(layout.pages)} pages in {layout.processing_time:.2f}s using {layout.method}."
+        )
+        content.append(create_text_content(summary))
+
+        if output_mode in ("json", "all"):
+            content.append(
+                create_text_content(
+                    json.dumps(layout.model_dump(), ensure_ascii=False, indent=2)
+                )
+            )
+
+        if output_mode in ("html", "all"):
+            combined_html = "<style>" + layout.css + "</style>" + "".join(page.html for page in layout.pages)
+            content.append(create_text_content(combined_html))
+
+        return MCPToolResult(content=content)
+

--- a/MCP/PDF/src/pdf_mcp_server/utils/__init__.py
+++ b/MCP/PDF/src/pdf_mcp_server/utils/__init__.py
@@ -11,7 +11,7 @@ from .exceptions import (
     ModelLoadError,
     ValidationError
 )
-from .logging_config import setup_logging
+from .logging_config import setup_logging, get_logger
 from .file_utils import (
     ensure_directory,
     cleanup_temp_files,
@@ -32,6 +32,7 @@ __all__ = [
     'ModelLoadError',
     'ValidationError',
     'setup_logging',
+    'get_logger',
     'ensure_directory',
     'cleanup_temp_files',
     'get_file_hash',

--- a/MCP/PDF/src/pdf_mcp_server/utils/docx_exporter.py
+++ b/MCP/PDF/src/pdf_mcp_server/utils/docx_exporter.py
@@ -39,7 +39,7 @@ def _to_dict(obj: Any) -> Dict[str, Any]:
     if hasattr(obj, "model_dump"):
         return obj.model_dump()
     if isinstance(obj, BaseModel):  # type: ignore
-        return obj.dict()
+        return obj.model_dump()
     # Last resort: best-effort
     return dict(obj)
 

--- a/MCP/PDF/src/pdf_mcp_server/utils/geometry.py
+++ b/MCP/PDF/src/pdf_mcp_server/utils/geometry.py
@@ -1,0 +1,161 @@
+"""Geometry helpers for PDF coordinate normalization.
+
+The PDF toolchain mixes coordinate systems depending on the backend. This
+module centralises conversions so that layout reconstruction, table placement
+and other downstream consumers rely on a single canonical format:
+
+* origin at the top-left corner of the page
+* coordinates expressed in PDF points (float)
+* bounding boxes guaranteed to be ordered (x0 <= x1, y0 <= y1)
+
+In addition to the normalisation routine the module exposes small helpers for
+area, IoU and distance computations that are frequently required when aligning
+recognised elements to geometric primitives.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence, Tuple, Union
+
+try:  # Optional dependency at runtime; callers must guard usage accordingly.
+    import fitz  # type: ignore
+except Exception:  # pragma: no cover - handled by graceful degradation
+    fitz = None  # type: ignore
+
+from ..models import BoundingBox
+
+
+BBoxLike = Union[BoundingBox, Sequence[float], Tuple[float, float, float, float]]
+
+
+@dataclass(frozen=True)
+class NormalizationOptions:
+    """Options controlling the behaviour of :func:`normalize_bbox`."""
+
+    clamp: bool = True
+    origin_top_left: bool = True
+
+
+def _ensure_rect(raw: BBoxLike) -> "fitz.Rect":
+    if fitz is None:  # pragma: no cover - defensive, should be guarded by callers
+        raise RuntimeError("PyMuPDF is required for geometry normalisation")
+
+    if isinstance(raw, BoundingBox):
+        return fitz.Rect(raw.x0, raw.y0, raw.x1, raw.y1)
+
+    if isinstance(raw, Iterable):
+        values = list(raw)
+        if len(values) != 4:
+            raise ValueError("Bounding box iterable must contain exactly 4 numbers")
+        return fitz.Rect(*values)
+
+    raise TypeError(f"Unsupported bounding box type: {type(raw)!r}")
+
+
+def normalize_bbox(
+    page: "fitz.Page",
+    raw_bbox: BBoxLike,
+    *,
+    options: Optional[NormalizationOptions] = None,
+) -> BoundingBox:
+    """Convert a bounding box into the canonical coordinate system.
+
+    Args:
+        page: PyMuPDF page instance owning the coordinates
+        raw_bbox: Bounding box in any page-specific coordinate system
+        options: Optional normalisation flags
+
+    Returns:
+        A :class:`BoundingBox` anchored at the top-left corner of the page.
+    """
+
+    if fitz is None:  # pragma: no cover - defensive, runtime guard
+        raise RuntimeError("PyMuPDF is not available; cannot normalise bounding boxes")
+
+    opts = options or NormalizationOptions()
+    rect = _ensure_rect(raw_bbox)
+
+    # Apply page rotation and crop offsets so that coordinates are expressed
+    # relative to the final rendered page rectangle.
+    matrix = fitz.Matrix(1, 0, 0, 1, 0, 0)
+    if getattr(page, "rotation", 0):
+        matrix = page.rotation_matrix * matrix
+    rect = rect.transform(matrix)
+
+    if hasattr(page, "cropbox_position"):
+        crop_x, crop_y = page.cropbox_position
+        rect = fitz.Rect(rect.x0 - crop_x, rect.y0 - crop_y, rect.x1 - crop_x, rect.y1 - crop_y)
+
+    page_rect = page.rect
+    width = float(page_rect.width)
+    height = float(page_rect.height)
+
+    x0 = min(rect.x0, rect.x1)
+    y0 = min(rect.y0, rect.y1)
+    x1 = max(rect.x0, rect.x1)
+    y1 = max(rect.y0, rect.y1)
+
+    if opts.origin_top_left:
+        # PDF coordinates are bottom-left by default; invert to top-left origin.
+        y0, y1 = height - y1, height - y0
+
+    if opts.clamp:
+        x0 = max(0.0, min(x0, width))
+        x1 = max(0.0, min(x1, width))
+        y0 = max(0.0, min(y0, height))
+        y1 = max(0.0, min(y1, height))
+
+    # Ensure non-degenerate boxes even when upstream data is imperfect.
+    if x1 - x0 < 1e-3:
+        x1 = min(width, x0 + 1e-3)
+    if y1 - y0 < 1e-3:
+        y1 = min(height, y0 + 1e-3)
+
+    return BoundingBox(x0=float(x0), y0=float(y0), x1=float(x1), y1=float(y1))
+
+
+def bbox_area(bbox: BoundingBox) -> float:
+    return max(0.0, (bbox.x1 - bbox.x0)) * max(0.0, (bbox.y1 - bbox.y0))
+
+
+def bbox_intersection(a: BoundingBox, b: BoundingBox) -> float:
+    x0 = max(a.x0, b.x0)
+    y0 = max(a.y0, b.y0)
+    x1 = min(a.x1, b.x1)
+    y1 = min(a.y1, b.y1)
+    if x1 <= x0 or y1 <= y0:
+        return 0.0
+    return (x1 - x0) * (y1 - y0)
+
+
+def bbox_iou(a: BoundingBox, b: BoundingBox) -> float:
+    inter = bbox_intersection(a, b)
+    if inter <= 0:
+        return 0.0
+    union = bbox_area(a) + bbox_area(b) - inter
+    if union <= 0:
+        return 0.0
+    return inter / union
+
+
+def bbox_center(bbox: BoundingBox) -> Tuple[float, float]:
+    return (bbox.x0 + bbox.x1) / 2.0, (bbox.y0 + bbox.y1) / 2.0
+
+
+def bbox_distance(a: BoundingBox, b: BoundingBox) -> float:
+    ax, ay = bbox_center(a)
+    bx, by = bbox_center(b)
+    return ((ax - bx) ** 2 + (ay - by) ** 2) ** 0.5
+
+
+__all__ = [
+    "NormalizationOptions",
+    "normalize_bbox",
+    "bbox_area",
+    "bbox_intersection",
+    "bbox_iou",
+    "bbox_center",
+    "bbox_distance",
+]
+

--- a/MCP/PDF/src/pdf_mcp_server/worker.py
+++ b/MCP/PDF/src/pdf_mcp_server/worker.py
@@ -70,6 +70,7 @@ def process_job(
         "include_grobid": options.get("include_grobid", False),
         "table_engine": options.get("table_engine"),
         "formula_model": options.get("formula_model"),
+        "reconstruct_layout": options.get("reconstruct_layout", False),
     }
 
     import asyncio  # 局部导入，避免同步环境提前加载
@@ -83,7 +84,7 @@ def process_job(
         return result
 
     result = asyncio.run(_run())  # 在同步上下文运行协程
-    res_dict = result.dict()  # Pydantic 模型转字典
+    res_dict = result.model_dump()  # Pydantic 模型转字典
 
     out: Dict[str, Any] = {"status": "done", "result": res_dict}  # 基础返回结构
 

--- a/MCP/PDF/tests/test_cli_reconstruct.py
+++ b/MCP/PDF/tests/test_cli_reconstruct.py
@@ -1,0 +1,137 @@
+"""Tests covering CLI flags for layout reconstruction."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+import types
+
+from pdf_mcp_server.models import ProcessingRequest
+
+stub_main = types.ModuleType("pdf_mcp_server.main")
+
+def _noop_main(*_args, **_kwargs):  # pragma: no cover - unused in tests
+    return None
+
+stub_main.main = _noop_main
+sys.modules.setdefault("pdf_mcp_server.main", stub_main)
+
+from pdf_mcp_server import cli as cli_module
+
+
+class DummyProcessor:
+    instances = []
+    requests = []
+
+    def __init__(self, config):
+        self.config = config
+        self._requests = []
+        DummyProcessor.instances.append(self)
+
+    async def initialize(self):  # pragma: no cover - trivial
+        return None
+
+    async def process(self, request):
+        self._requests.append(request)
+        DummyProcessor.requests.append(request)
+
+        class DummyResult:
+            def __init__(self, req):
+                self._req = req
+
+            def model_dump(self, *_, **__):
+                return {
+                    "file": self._req.file_path,
+                    "reconstruct_layout": self._req.reconstruct_layout,
+                }
+
+            def __str__(self):  # pragma: no cover - CLI fallback
+                return json.dumps(self.model_dump())
+
+        return DummyResult(request)
+
+    async def cleanup(self):  # pragma: no cover - trivial
+        return None
+
+
+@pytest.fixture(autouse=True)
+def reset_dummy_processor(monkeypatch):
+    DummyProcessor.instances.clear()
+    DummyProcessor.requests.clear()
+
+    monkeypatch.setattr(cli_module, "PDFProcessor", DummyProcessor)
+
+    def _load_config(cls, *_args, **_kwargs):
+        return cli_module.Config()
+
+    monkeypatch.setattr(
+        cli_module.Config,
+        "load_config",
+        classmethod(_load_config),
+        raising=False,
+    )
+
+
+def _create_pdf(tmp_path: Path, name: str = "sample.pdf") -> Path:
+    pdf_path = tmp_path / name
+    pdf_path.write_bytes(b"%PDF-1.4\n%\xff\xff\xff\xff\n")
+    return pdf_path
+
+
+def test_process_command_sets_reconstruct_layout(tmp_path):
+    runner = CliRunner()
+    pdf_path = _create_pdf(tmp_path)
+
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "--quiet",
+            "process",
+            "--file",
+            str(pdf_path),
+            "--mode",
+            "full_pipeline",
+            "--reconstruct-layout",
+        ],
+        standalone_mode=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert DummyProcessor.requests, "process() should be invoked"
+    assert DummyProcessor.requests[0].reconstruct_layout is True
+
+
+def test_batch_command_passes_reconstruct_layout(tmp_path):
+    runner = CliRunner()
+    pdf_one = _create_pdf(tmp_path, "one.pdf")
+    pdf_two = _create_pdf(tmp_path, "two.pdf")
+
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "--quiet",
+            "batch",
+            "--files",
+            str(pdf_one),
+            "--files",
+            str(pdf_two),
+            "--reconstruct-layout",
+        ],
+        standalone_mode=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(DummyProcessor.requests) == 2
+    assert all(req.reconstruct_layout for req in DummyProcessor.requests)
+
+    # When quiet mode is enabled the CLI prints a JSON summary; ensure it is valid.
+    summary = json.loads(result.output)
+    assert summary["successful"] == 2

--- a/MCP/PDF/tests/test_exceptions.py
+++ b/MCP/PDF/tests/test_exceptions.py
@@ -1,0 +1,24 @@
+"""Regression tests for MCP exception helpers."""
+
+import sys
+from pathlib import Path
+
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from pdf_mcp_server.mcp.exceptions import ToolExecutionException
+
+
+def test_tool_execution_exception_single_argument():
+    exc = ToolExecutionException("failure")
+    assert exc.execution_error == "failure"
+    assert exc.tool_name == "generic_tool"
+    assert "failure" in str(exc)
+
+
+def test_tool_execution_exception_with_tool_name():
+    exc = ToolExecutionException("read_text", "boom")
+    assert exc.execution_error == "boom"
+    assert exc.tool_name == "read_text"
+    assert "read_text" in str(exc)

--- a/MCP/PDF/tests/test_geometry_utils.py
+++ b/MCP/PDF/tests/test_geometry_utils.py
@@ -1,0 +1,60 @@
+"""Unit tests for geometry helper functions."""
+
+import sys
+from pathlib import Path
+
+import fitz
+import pytest
+
+
+# Ensure the src package is importable when tests execute from the repository root.
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from pdf_mcp_server.models import BoundingBox
+from pdf_mcp_server.utils.geometry import (
+    bbox_distance,
+    bbox_iou,
+    normalize_bbox,
+)
+
+
+def _make_page(width: int = 200, height: int = 100, rotation: int = 0):
+    doc = fitz.open()
+    page = doc.new_page(width=width, height=height)
+    if rotation:
+        page.set_rotation(rotation)
+    return doc, page
+
+
+def test_normalize_bbox_top_left_origin():
+    doc, page = _make_page()
+    try:
+        bbox = normalize_bbox(page, (0, 0, 20, 10))
+        assert bbox.x0 == pytest.approx(0)
+        assert bbox.y0 == pytest.approx(90)
+        assert bbox.x1 == pytest.approx(20)
+        assert bbox.y1 == pytest.approx(100)
+    finally:
+        doc.close()
+
+
+def test_normalize_bbox_rotated_page():
+    doc, page = _make_page(rotation=90)
+    try:
+        bbox = normalize_bbox(page, (0, 0, 20, 10))
+        assert bbox.x0 == pytest.approx(90)
+        assert bbox.y0 == pytest.approx(180)
+        assert bbox.x1 == pytest.approx(100)
+        assert bbox.y1 == pytest.approx(200)
+    finally:
+        doc.close()
+
+
+def test_bbox_distance_and_iou():
+    a = BoundingBox(x0=0, y0=0, x1=10, y1=10)
+    b = BoundingBox(x0=5, y0=5, x1=15, y1=15)
+
+    assert bbox_iou(a, b) == pytest.approx(25 / 175)
+    assert bbox_distance(a, b) == pytest.approx(((5) ** 2 + (5) ** 2) ** 0.5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+-e ./MCP/PDF
+pylint>=3.0.0


### PR DESCRIPTION
## Summary
- allow `ToolExecutionException` to accept legacy single-argument calls while preserving structured error metadata
- default processing metadata to the package version and expose a root requirements stub so CI can install dependencies
- add regression tests covering the updated exception API

## Testing
- pytest MCP/PDF/tests/test_exceptions.py MCP/PDF/tests/test_geometry_utils.py MCP/PDF/tests/test_cli_reconstruct.py
- python -m compileall MCP/PDF/src/pdf_mcp_server


------
https://chatgpt.com/codex/tasks/task_e_68e4eedf01ac832488916503aa3e7258