### PR TITLE
Fix layout tool errors and normalize page handling

### DIFF
--- a/MCP/PDF/src/pdf_mcp_server/mcp/exceptions.py
+++ b/MCP/PDF/src/pdf_mcp_server/mcp/exceptions.py
@@ -109,74 +109,40 @@ class ToolExecutionException(MCPException):
 
     def __init__(
         self,
-codex/locate-pdf-mcp-server-project-uq2ubf
-        tool_name: str,
-        execution_error: Optional[str] = None,
-        original_exception: Optional[Exception] = None
-    ):
-        # Historical call sites only provided a human readable message. To remain
-        # backwards compatible we treat the single argument form as the
-        # ``execution_error`` and fall back to an ``unknown`` tool name.
-        if execution_error is None:
-            execution_error = tool_name
-            tool_name = "unknown_tool"
-
-        message = f"Tool '{tool_name}' execution failed: {execution_error}"
-
         tool_name_or_message: str,
         execution_error: Optional[str] = None,
         original_exception: Optional[Exception] = None,
         *,
         tool_name: Optional[str] = None,
     ):
-        """Create a tool execution error.
-
-        The historical call-site signature was ``ToolExecutionException(message)``
-        even though the class originally required both ``tool_name`` and an error
-        string.  Pylint correctly flagged these calls as missing required
-        arguments.  To remain backward compatible (and to keep the call-sites
-        simple for generic tools) we accept either ``ToolExecutionException("msg")``
-        or ``ToolExecutionException("tool", "msg")`` as well as the explicit
-        keyword form ``ToolExecutionException("msg", tool_name="tool")``.
-        """
+        """Create a tool execution error with backward compatible signatures."""
 
         if execution_error is None and tool_name is None:
-            # Called with only a message. Use a generic tool name so the final
-            # message still reads naturally.
             resolved_tool_name = "generic_tool"
             resolved_error = tool_name_or_message
             final_message = f"Tool execution failed: {resolved_error}"
         else:
-            # Either the legacy two-argument form or explicit keyword usage.
             resolved_tool_name = tool_name or tool_name_or_message
             resolved_error = execution_error or tool_name_or_message
             final_message = (
                 f"Tool '{resolved_tool_name}' execution failed: {resolved_error}"
             )
 
-main
         details = {
             'tool_name': resolved_tool_name,
             'execution_error': resolved_error,
         }
 
-        if original_exception:
+        if original_exception is not None:
             details['original_exception'] = {
                 'type': type(original_exception).__name__,
-                'message': str(original_exception)
+                'message': str(original_exception),
             }
-
-codex/locate-pdf-mcp-server-project-uq2ubf
-        super().__init__(message, 'TOOL_EXECUTION_ERROR', details)
-        self.tool_name = tool_name
-        self.execution_error = execution_error
 
         super().__init__(final_message, 'TOOL_EXECUTION_ERROR', details)
         self.tool_name = resolved_tool_name
         self.execution_error = resolved_error
-main
         self.original_exception = original_exception
-
 
 class MCPTimeoutException(MCPException):
     """Exception raised when MCP operations timeout."""

--- a/MCP/PDF/src/pdf_mcp_server/models.py
+++ b/MCP/PDF/src/pdf_mcp_server/models.py
@@ -24,15 +24,12 @@ from datetime import datetime  # 日期时间处理
 from pydantic import BaseModel, Field, field_validator  # 数据验证和序列化框架
 
 try:
- codex/locate-pdf-mcp-server-project-uq2ubf
     PACKAGE_VERSION = metadata.version("pdf-mcp-server")
 except metadata.PackageNotFoundError:  # pragma: no cover - fallback when running from source
-    PACKAGE_VERSION = "0.1.0"
-
-    from . import __version__ as _PACKAGE_VERSION
-except ImportError:  # pragma: no cover - package metadata fallback
-    _PACKAGE_VERSION = "0.0.0"
- main
+    try:
+        from . import __version__ as PACKAGE_VERSION  # type: ignore
+    except ImportError:  # pragma: no cover - package metadata fallback
+        PACKAGE_VERSION = "0.0.0"
 
 
 class ProcessingMode(str, Enum):
@@ -386,11 +383,7 @@ class ProcessingMetadata(BaseModel):
     engines_used: List[str] = Field(..., description="使用的引擎/模型列表")
     file_info: PDFInfo = Field(..., description="PDF文件信息")
     timestamp: datetime = Field(default_factory=datetime.now, description="处理时间戳")
- codex/locate-pdf-mcp-server-project-uq2ubf
     version: str = Field(PACKAGE_VERSION, description="服务器版本")
-
-    version: str = Field(_PACKAGE_VERSION, description="服务器版本")
- main
     errors: List[str] = Field(default_factory=list, description="遇到的非致命错误列表")
     warnings: List[str] = Field(default_factory=list, description="生成的警告列表")
 
@@ -459,7 +452,7 @@ class ProcessingRequest(BaseModel):
     file_path: Optional[str] = Field(None, description="本地文件路径")
     file_url: Optional[str] = Field(None, description="远程文件URL")
     mode: ProcessingMode = Field(ProcessingMode.FULL, description="处理模式")
-    pages: Optional[List[int]] = Field(None, description="要处理的特定页面列表")
+    pages: Optional[List[int]] = Field(None, description="要处理的特定页面列表（从1开始）")
     
     # 文本提取选项
     include_bbox: bool = Field(False, description="是否包含边界框信息")

--- a/MCP/PDF/src/pdf_mcp_server/processors/__init__.py
+++ b/MCP/PDF/src/pdf_mcp_server/processors/__init__.py
@@ -14,10 +14,7 @@ from .table_extractor import TableExtractor
 from .ocr_processor import OCRProcessor
 from .formula_extractor import FormulaExtractor
 from .document_analyzer import DocumentAnalyzer
-try:
-    from .layout_reconstructor import LayoutReconstructor
-except Exception:  # pragma: no cover - optional dependency
-    LayoutReconstructor = None  # type: ignore
+
 __all__ = [
     "PDFProcessor",
     "TextExtractor",
@@ -25,10 +22,4 @@ __all__ = [
     "OCRProcessor",
     "FormulaExtractor",
     "DocumentAnalyzer",
-codex/locate-pdf-mcp-server-project-uq2ubf
 ]
-    "LayoutReconstructor",
-]
-if LayoutReconstructor is None:  # pragma: no cover - optional
-    __all__.remove("LayoutReconstructor")
-main

--- a/MCP/PDF/src/pdf_mcp_server/processors/formula_extractor.py
+++ b/MCP/PDF/src/pdf_mcp_server/processors/formula_extractor.py
@@ -48,6 +48,7 @@ from ..models import (
     FormulaModel
 )
 from ..utils.config import Config
+from ..utils.page_utils import resolve_page_indices
 from ..utils.exceptions import PDFProcessingError
 
 
@@ -153,12 +154,9 @@ class FormulaExtractor:
             
             try:
                 # Determine pages to process
-                page_range = request.pages if request.pages else range(len(doc))
-                
-                for page_num in page_range:
-                    if page_num >= len(doc):
-                        continue
-                    
+                page_indices = resolve_page_indices(request.pages, len(doc))
+
+                for page_num in page_indices:
                     page_formulas = await self._extract_formulas_from_page(
                         doc[page_num], page_num, request
                     )

--- a/MCP/PDF/src/pdf_mcp_server/processors/layout_reconstructor.py
+++ b/MCP/PDF/src/pdf_mcp_server/processors/layout_reconstructor.py
@@ -14,7 +14,7 @@ import time
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 try:  # Optional dependency
     import fitz  # type: ignore
@@ -35,6 +35,7 @@ from ..models import (
     TextSpan,
 )
 from ..utils.config import Config
+from ..utils.page_utils import resolve_page_indices
 from ..utils.exceptions import PDFProcessingError
 from ..utils.geometry import (
     bbox_distance,
@@ -220,16 +221,7 @@ class LayoutReconstructor:
     # Helpers
     # ------------------------------------------------------------------
     def _resolve_pages(self, pages: Optional[List[int]], total_pages: int) -> List[int]:
-        if not pages:
-            return list(range(total_pages))
-        resolved: List[int] = []
-        seen: Set[int] = set()
-        for page in pages:
-            index = page - 1 if page > 0 else 0
-            if 0 <= index < total_pages and index not in seen:
-                resolved.append(index)
-                seen.add(index)
-        return resolved
+        return resolve_page_indices(pages, total_pages)
 
     def _linear_sum_assignment(
         self, cost_matrix: List[List[float]], filler: float

--- a/MCP/PDF/src/pdf_mcp_server/processors/ocr_processor.py
+++ b/MCP/PDF/src/pdf_mcp_server/processors/ocr_processor.py
@@ -210,7 +210,8 @@ class OCRProcessor:
         # Add page range if specified
         if request.pages:
             max_requested = max(request.pages)
-            page_indices = resolve_page_indices(request.pages, max_requested)
+            total_pages = max(max_requested, 1)
+            page_indices = resolve_page_indices(request.pages, total_pages)
             ocr_args['pages'] = ",".join(str(index + 1) for index in page_indices)
         
         try:

--- a/MCP/PDF/src/pdf_mcp_server/processors/ocr_processor.py
+++ b/MCP/PDF/src/pdf_mcp_server/processors/ocr_processor.py
@@ -30,6 +30,7 @@ except ImportError:
 
 from ..models import ProcessingRequest
 from ..utils.config import Config
+from ..utils.page_utils import resolve_page_indices
 from ..utils.exceptions import PDFProcessingError
 
 
@@ -208,11 +209,9 @@ class OCRProcessor:
         
         # Add page range if specified
         if request.pages:
-            # OCRmyPDF uses 1-indexed pages
-            page_ranges = []
-            for page in sorted(request.pages):
-                page_ranges.append(f"{page + 1}")
-            ocr_args['pages'] = ",".join(page_ranges)
+            max_requested = max(request.pages)
+            page_indices = resolve_page_indices(request.pages, max_requested)
+            ocr_args['pages'] = ",".join(str(index + 1) for index in page_indices)
         
         try:
             # Run OCRmyPDF
@@ -262,12 +261,9 @@ class OCRProcessor:
                 ocr_results = []
                 
                 # Determine pages to process
-                page_range = request.pages if request.pages else range(len(doc))
-                
-                for page_num in page_range:
-                    if page_num >= len(doc):
-                        continue
-                    
+                page_indices = resolve_page_indices(request.pages, len(doc))
+
+                for page_num in page_indices:
                     page = doc[page_num]
                     
                     # Convert page to image

--- a/MCP/PDF/src/pdf_mcp_server/processors/table_extractor.py
+++ b/MCP/PDF/src/pdf_mcp_server/processors/table_extractor.py
@@ -40,6 +40,7 @@ from ..models import (
     OutputFormat,
 )
 from ..utils.config import Config
+from ..utils.page_utils import resolve_page_indices
 from ..utils.exceptions import PDFProcessingError
 
 
@@ -417,12 +418,9 @@ class TableExtractor:
         try:
             with pdfplumber.open(str(file_path)) as pdf:
                 # Determine pages to process
-                page_range = request.pages if request.pages else range(len(pdf.pages))
-                
-                for page_num in page_range:
-                    if page_num >= len(pdf.pages):
-                        continue
-                    
+                page_indices = resolve_page_indices(request.pages, len(pdf.pages))
+
+                for page_num in page_indices:
                     page = pdf.pages[page_num]
                     page_tables = page.extract_tables()
                     

--- a/MCP/PDF/src/pdf_mcp_server/processors/text_extractor.py
+++ b/MCP/PDF/src/pdf_mcp_server/processors/text_extractor.py
@@ -31,6 +31,7 @@ from ..models import (
     TextSpan,
 )
 from ..utils.config import Config
+from ..utils.page_utils import resolve_page_indices
 from ..utils.exceptions import PDFProcessingError
 
 
@@ -126,12 +127,9 @@ class TextExtractor:
             include_bbox = getattr(request, "include_bbox", False)
             
             # Determine pages to process
-            page_range = request.pages if request.pages else range(len(doc))
-            
-            for page_num in page_range:
-                if page_num >= len(doc):
-                    continue
-                
+            page_indices = resolve_page_indices(request.pages, len(doc))
+
+            for page_num in page_indices:
                 page = doc[page_num]
                 
                 # Extract text with different methods based on requirements
@@ -293,12 +291,9 @@ class TextExtractor:
             include_bbox = getattr(request, "include_bbox", False)
             
             # Determine pages to process
-            page_range = request.pages if request.pages else range(len(pdf.pages))
-            
-            for page_num in page_range:
-                if page_num >= len(pdf.pages):
-                    continue
-                
+            page_indices = resolve_page_indices(request.pages, len(pdf.pages))
+
+            for page_num in page_indices:
                 page = pdf.pages[page_num]
                 
                 # Extract text with different methods

--- a/MCP/PDF/src/pdf_mcp_server/tools/layout_reconstruction.py
+++ b/MCP/PDF/src/pdf_mcp_server/tools/layout_reconstruction.py
@@ -124,20 +124,21 @@ class ReconstructLayoutTool(PDFTool):
         try:
             table_engine = TableEngine(table_engine_value)
         except Exception as exc:  # pragma: no cover - enum validation
-codex/locate-pdf-mcp-server-project-uq2ubf
-            raise ToolExecutionException(self.name, f"Unsupported table engine: {table_engine_value}", exc) from exc
-
-            raise ToolExecutionException(f"Unsupported table engine: {table_engine_value}") from exc
-main
+            raise ToolExecutionException(
+                f"Unsupported table engine: {table_engine_value}",
+                tool_name=self.name,
+                original_exception=exc,
+            ) from exc
 
         try:
             formula_model = FormulaModel(formula_model_value)
         except Exception as exc:  # pragma: no cover - enum validation
-codex/locate-pdf-mcp-server-project-uq2ubf
-            raise ToolExecutionException(self.name, f"Unsupported formula model: {formula_model_value}", exc) from exc
+            raise ToolExecutionException(
+                f"Unsupported formula model: {formula_model_value}",
+                tool_name=self.name,
+                original_exception=exc,
+            ) from exc
 
-            raise ToolExecutionException(f"Unsupported formula model: {formula_model_value}") from exc
-main
 
         config = Config.load()
         processor = PDFProcessor(config)
@@ -155,25 +156,20 @@ main
                 reconstruct_layout=True,
             )
             result = await processor.process(request)
+        except ToolExecutionException:
+            raise
         except Exception as exc:
             self.logger.error("Layout reconstruction failed: %s", exc, exc_info=True)
-codex/locate-pdf-mcp-server-project-uq2ubf
-
-            await processor.cleanup()
-main
-            return MCPToolResult(
-                content=[create_error_content(f"Layout reconstruction failed: {exc}")],
-                isError=True,
-            )
-codex/locate-pdf-mcp-server-project-uq2ubf
+            raise ToolExecutionException(
+                "Layout reconstruction failed",
+                tool_name=self.name,
+                original_exception=exc,
+            ) from exc
         finally:
             await processor.cleanup()
 
-
-        await processor.cleanup()
-main
-
         layout = result.content.layout if result and result.content else None
+
         if not layout:
             return MCPToolResult(
                 content=[create_error_content("Layout reconstruction returned no result")],

--- a/MCP/PDF/src/pdf_mcp_server/utils/__init__.py
+++ b/MCP/PDF/src/pdf_mcp_server/utils/__init__.py
@@ -24,6 +24,7 @@ from .validation import (
     validate_processing_request,
     sanitize_filename
 )
+from .page_utils import resolve_page_indices
 
 __all__ = [
     'Config',
@@ -40,5 +41,6 @@ __all__ = [
     'get_file_size',
     'validate_pdf_file',
     'validate_processing_request',
-    'sanitize_filename'
+    'sanitize_filename',
+    'resolve_page_indices'
 ]

--- a/MCP/PDF/src/pdf_mcp_server/utils/page_utils.py
+++ b/MCP/PDF/src/pdf_mcp_server/utils/page_utils.py
@@ -1,0 +1,45 @@
+"""Page handling helpers for PDF processing."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Set
+
+
+def resolve_page_indices(pages: Optional[Iterable[int]], total_pages: int) -> List[int]:
+    """Convert requested pages to zero-based indices within document bounds.
+
+    Args:
+        pages: Iterable of 1-based page numbers supplied by callers. ``None``
+            or an empty iterable selects every available page. Values less than
+            ``1`` default to the first page so that legacy zero-based inputs do
+            not underflow.
+        total_pages: Total number of pages available in the document.
+
+    Returns:
+        A list of zero-based page indices, preserving the original ordering and
+        removing duplicates while clamping values to the available range.
+    """
+
+    if total_pages <= 0:
+        return []
+
+    if not pages:
+        return list(range(total_pages))
+
+    resolved: List[int] = []
+    seen: Set[int] = set()
+    max_index = total_pages - 1
+
+    for page in pages:
+        if page is None:
+            continue
+
+        index = page - 1 if page > 0 else 0
+        if index > max_index:
+            index = max_index
+
+        if index not in seen:
+            resolved.append(index)
+            seen.add(index)
+
+    return resolved


### PR DESCRIPTION
## Summary
- allow `ToolExecutionException` to support legacy message-only calls while preserving enriched context about original exceptions
- surface unsupported enum selections and runtime failures from the layout reconstruction tool with tool-aware errors while guaranteeing processor cleanup
- derive processing metadata version from installed package metadata, document 1-based `pages` inputs, and export a shared page resolver
- normalize page handling across layout, text, table, formula, and OCR processors using the shared helper to keep downstream work in sync

## Testing
- python -m compileall MCP/PDF/src/pdf_mcp_server

------
https://chatgpt.com/codex/tasks/task_e_68e7f4b5440483249058aa126600537e